### PR TITLE
Added ServiceModule tank type to procedural probe core

### DIFF
--- a/GameData/ROTanks/Parts/Probes/ROT-ProbeCore.cfg
+++ b/GameData/ROTanks/Parts/Probes/ROT-ProbeCore.cfg
@@ -79,6 +79,7 @@ PART
 		typeAvailable = SM-II
 		typeAvailable = SM-III
 		typeAvailable = SM-IV
+		typeAvailable = ServiceModule
 		TANK
 		{
 			name = ElectricCharge


### PR DESCRIPTION
I'm not sure if this was intended or not, but while usual RO probes have tank type of "ServiceModule", procedural one can use any tank type but ServiceModule. This prevents from using it with ion thrusters (argon or xenon gas).