### PR TITLE
Fix Dome-Framed-M Mount volume

### DIFF
--- a/GameData/ROTanks/Data/Models/ModelData-Adapters-Domes.cfg
+++ b/GameData/ROTanks/Data/Models/ModelData-Adapters-Domes.cfg
@@ -73,7 +73,7 @@ ROL_MODEL
 	diameter = 5
 	volume = 29.0331
 	cost = 0
-    upperDiameter = 2.5
+    upperDiameter = 5
     lowerDiameter = 5
 	topNode = 0, 2.5, 0, 0, 1, 0
 	effectiveLength = 1.25


### PR DESCRIPTION
Per discord: the smaller upperdiameter somehow leads to excessive volume
in the mount position.

Doesn't make a lot of sense, and hints at a code problem, but this change
makes it consistent with the other 2 domes.