### PR TITLE
Unrotate Pyrios, Direct mounts

### DIFF
--- a/GameData/ROTanks/Data/Models/ModelData-Mounts-Engine.cfg
+++ b/GameData/ROTanks/Data/Models/ModelData-Mounts-Engine.cfg
@@ -221,7 +221,7 @@ ROL_MODEL
 	modelName = ROTanks/Assets/SC-ENG-MOUNT-PYRIOS
     orientation = BOTTOM
 	verticalOffset = -2.3
-	rotationOffset = 0,-90,0
+	rotationOffset = 0,0,0
 	height = 1.333333
 	diameter = 5
     upperDiameter = 5
@@ -258,7 +258,7 @@ ROL_MODEL
 	modelName = ROTanks/Assets/SC-ENG-MOUNT-DIRECT
     orientation = BOTTOM
 	verticalOffset = 0
-	rotationOffset = 0,-90,0
+	rotationOffset = 0,0,0
 	height = 2.5
 	diameter = 5
     upperDiameter = 5


### PR DESCRIPTION
So that surface-attached parts are oriented correctly.
Makes orientation "wrong" when used as a core, but that can
be fixed by rotating the part. Rotating a surface-attached part
doesn't do the right thing.