### PR TITLE
Fix incorrect BumpMap assigned on ROT-Adapter-Plain

### DIFF
--- a/GameData/ROTanks/Data/TextureSets/TextureSets-Adapters.cfg
+++ b/GameData/ROTanks/Data/TextureSets/TextureSets-Adapters.cfg
@@ -77,7 +77,7 @@ KSP_TEXTURE_SET
     {
         shader = TU/Metallic
         texture = _MainTex, ROTanks/Assets/SC-ADPT1-DIFF
-        texture = _BumpMap, ROTanks/Assets/SC-ADPT1-NRM-PLAIN
+        texture = _BumpMap, ROTanks/Assets/SC-ADPT1-NRM
         texture = _MaskTex, ROTanks/Assets/SC-ADPT1-MASK-STRIPES1
         texture = _MetallicGlossMap, ROTanks/Assets/SC-ADPT1-MET-STD
         excludeMesh = SC-ADPT-ENDCAP


### PR DESCRIPTION
The config for ROT-Adapter-Plain was pointing to an incorrect normal map.  Referenced SSTU for the correct value then tested.