### PR TITLE
Add 45-degree S-IC, rd108 mounts

### DIFF
--- a/GameData/ROTanks/Data/Models/ModelData-Mounts-Engine.cfg
+++ b/GameData/ROTanks/Data/Models/ModelData-Mounts-Engine.cfg
@@ -18,6 +18,25 @@ ROL_MODEL
 
 ROL_MODEL
 {
+	name = Mount-S-IC-45
+	title = Saturn S-IC 2
+	modelName = ROTanks/Assets/SC-ENG-MOUNT-SATURN-V
+    orientation = BOTTOM
+	verticalOffset = 0
+	rotationOffset = 0,-45,0
+	height = 2.24
+	diameter = 5
+    upperDiameter = 5
+    lowerDiameter = 6
+	volume = 46.7618
+	topNode = 0, 0, 0, 0, 1, 0, 2
+	bottomNode = 0, -2.24, 0, 0, -1, 0, 2
+	effectiveLength = 2.2088
+	additionalVolume = 0
+}
+
+ROL_MODEL
+{
 	name = Mount-S-II
 	title = Saturn S-II
 	modelName = ROTanks/Assets/SC-ENG-MOUNT-S-II
@@ -316,6 +335,25 @@ ROL_MODEL
     orientation = BOTTOM
 	verticalOffset = 0
 	rotationOffset = 0,-45,0
+	height = 0.05
+	diameter = 1.4375
+    upperDiameter = 1.4375
+    lowerDiameter = 1.4375
+	volume = 0.1
+	topNode = 0, 0, 0, 0, 1, 0, 2
+	bottomNode = 0, -0.05, 0, 0, -1, 0, 2
+	effectiveLength = 0.4686
+	additionalVolume = 0
+}
+
+ROL_MODEL
+{
+	name = Mount-RD-108-45
+	title = RD-108 2
+	modelName = ROTanks/Assets/SC-ENG-MOUNT-RD-108
+    orientation = BOTTOM
+	verticalOffset = 0
+	rotationOffset = 0,0,0
 	height = 0.05
 	diameter = 1.4375
     upperDiameter = 1.4375

--- a/GameData/ROTanks/Data/TextureSets/TextureSets-Mounts-RD-10x.cfg
+++ b/GameData/ROTanks/Data/TextureSets/TextureSets-Mounts-RD-10x.cfg
@@ -1,4 +1,4 @@
-@ROL_MODEL[Mount-RD-107|Mount-RD-108]:FOR[ROTanks]
+@ROL_MODEL[Mount-RD-107|Mount-RD-108|Mount-RD-108-45]:FOR[ROTanks]
 {
 	KSP_TEXTURE_SET
 	{

--- a/GameData/ROTanks/Data/TextureSets/TextureSets-Mounts1.cfg
+++ b/GameData/ROTanks/Data/TextureSets/TextureSets-Mounts1.cfg
@@ -1,4 +1,4 @@
-@ROL_MODEL[Mount-SLS|Mount-SLS-6|Mount-S-IC|Mount-Pyrios|Mount-Generic]:FOR[ROTanks]
+@ROL_MODEL[Mount-SLS|Mount-SLS-6|Mount-S-IC|Mount-S-IC-45|Mount-Pyrios|Mount-Generic]:FOR[ROTanks]
 {
     %defaultTextureSet = ROT-Mount-A
 	KSP_TEXTURE_SET

--- a/GameData/ROTanks/Parts/Tanks/ROT-GenericTank.cfg
+++ b/GameData/ROTanks/Parts/Tanks/ROT-GenericTank.cfg
@@ -303,6 +303,7 @@ PART
 
 			// Engine Mounts
 			model = Mount-S-IC
+			model = Mount-S-IC-45
 			model = Mount-S-II
 			model = Mount-S-IVB
 			model = Mount-Generic
@@ -320,6 +321,7 @@ PART
 			model = Mount-Delta-IV
 			model = Mount-RD-107
 			model = Mount-RD-108
+			model = Mount-RD-108-45
 			model = Mount-Skeletal-S
 			model = Mount-Skeletal-M
 			model = Mount-Skeletal-L


### PR DESCRIPTION
To be able to have a + engine layout instead of x, without having
to rotate the whole tank 45 degrees (which puts the side-pipes in
the wrong place)