### PR TITLE
Rotate pyrios, direct mounts on Booster tanks

### DIFF
--- a/GameData/ROTanks/Data/Models/ModelData-Mounts-Engine.cfg
+++ b/GameData/ROTanks/Data/Models/ModelData-Mounts-Engine.cfg
@@ -254,6 +254,25 @@ ROL_MODEL
 
 ROL_MODEL
 {
+	name = Mount-Pyrios-90
+	title = Pyrios
+	modelName = ROTanks/Assets/SC-ENG-MOUNT-PYRIOS
+	orientation = BOTTOM
+	verticalOffset = -2.3
+	rotationOffset = 0,90,0
+	height = 1.333333
+	diameter = 5
+	upperDiameter = 5
+	lowerDiameter = 7
+	volume = 70.9993
+	topNode = 0, 0, 0, 0, 1, 0, 2
+	bottomNode = 0, -1.33333333, 0, 0, -1, 0, 2
+	effectiveLength = 0
+	additionalVolume = 0
+}
+
+ROL_MODEL
+{
 	name = Mount-Nova
 	title = Nova
 	modelName = ROTanks/Assets/SC-ENG-MOUNT-NOVA
@@ -278,6 +297,25 @@ ROL_MODEL
     orientation = BOTTOM
 	verticalOffset = 0
 	rotationOffset = 0,0,0
+	height = 2.5
+	diameter = 5
+    upperDiameter = 5
+    lowerDiameter = 7
+	volume = 48.7726
+	topNode = 0, 0, 0, 0, 1, 0, 2
+	bottomNode = 0, -2.5, 0, 0, -1, 0, 2
+	effectiveLength = 0
+	additionalVolume = 0
+}
+
+ROL_MODEL
+{
+	name = Mount-Direct-90
+	title = Direct
+	modelName = ROTanks/Assets/SC-ENG-MOUNT-DIRECT
+    orientation = BOTTOM
+	verticalOffset = 0
+	rotationOffset = 0,90,0
 	height = 2.5
 	diameter = 5
     upperDiameter = 5

--- a/GameData/ROTanks/Data/TextureSets/TextureSets-Mounts1.cfg
+++ b/GameData/ROTanks/Data/TextureSets/TextureSets-Mounts1.cfg
@@ -1,4 +1,4 @@
-@ROL_MODEL[Mount-SLS|Mount-SLS-6|Mount-S-IC|Mount-Pyrios|Mount-Generic|Mount-S-IC-45]:FOR[ROTanks]
+@ROL_MODEL[Mount-SLS|Mount-SLS-6|Mount-S-IC|Mount-Pyrios|Mount-Pyrios-90|Mount-Generic|Mount-S-IC-45]:FOR[ROTanks]
 {
     %defaultTextureSet = ROT-Mount-A
 	KSP_TEXTURE_SET

--- a/GameData/ROTanks/Data/TextureSets/TextureSets-Mounts2.cfg
+++ b/GameData/ROTanks/Data/TextureSets/TextureSets-Mounts2.cfg
@@ -1,4 +1,4 @@
-@ROL_MODEL[Mount-Nova|Mount-Direct|Mount-S-II|Mount-S-IVB|Mount-Shroud-S|Mount-Shroud-M|Mount-Shroud-L|Mount-Shroud-XL]:FOR[ROTanks]
+@ROL_MODEL[Mount-Nova|Mount-Direct|Mount-Direct-90|Mount-S-II|Mount-S-IVB|Mount-Shroud-S|Mount-Shroud-M|Mount-Shroud-L|Mount-Shroud-XL]:FOR[ROTanks]
 {
     %defaultTextureSet = ROT-Mount-A
 

--- a/GameData/ROTanks/Parts/Tanks/ROT-BoosterTank.cfg
+++ b/GameData/ROTanks/Parts/Tanks/ROT-BoosterTank.cfg
@@ -162,9 +162,9 @@ PART
 			model = Mount-Shroud-XL
 			model = Mount-SLS
 			model = Mount-SLS-6
-			model = Mount-Pyrios
+			model = Mount-Pyrios-90
 			model = Mount-Nova
-			model = Mount-Direct
+			model = Mount-Direct-90
 			model = Mount-Delta-IV
 			model = Mount-RD-107
 			model = Mount-RD-108


### PR DESCRIPTION
So the bits sticking out are tangential instead of radial;
to avoid clipping the core tank