### PR TITLE
Saturn interstage mass changes, derived from NASA publication

### DIFF
--- a/GameData/ROTanks/Data/Models/ModelData-Interstages-Katniss.cfg
+++ b/GameData/ROTanks/Data/Models/ModelData-Interstages-Katniss.cfg
@@ -9,7 +9,7 @@ ROL_MODEL
 	lowerDiameter = 10.3
 	minVerticalScale = 0.5
 	maxVerticalScale = 3
-	mass = 10.113
+	mass = 5.240
 	cost = 6294
 	height = 5.5
 	volume = 0
@@ -26,7 +26,7 @@ ROL_MODEL
 	lowerDiameter = 10.3
 	minVerticalScale = 0.5
 	maxVerticalScale = 3
-	mass = 10.863
+	mass = 6.192
 	cost = 6894
 	height = 6.5
 	volume = 0
@@ -43,7 +43,7 @@ ROL_MODEL
 	lowerDiameter = 10.453
 	minVerticalScale = 0.5
 	maxVerticalScale = 3
-	mass = 11.26
+	mass = 6.4
 	cost = 7136
 	height = 6.5
 	volume = 0
@@ -60,7 +60,7 @@ ROL_MODEL
 	lowerDiameter = 10.3
 	minVerticalScale = 0.5
 	maxVerticalScale = 3
-	mass = 10.988
+	mass = 7.621
 	cost = 7794
 	height = 8
 	volume = 0
@@ -77,7 +77,7 @@ ROL_MODEL
 	lowerDiameter = 10.3
 	minVerticalScale = 0.5
 	maxVerticalScale = 3
-	mass = 10.988
+	mass = 7.621
 	cost = 7794
 	height = 8
 	volume = 0
@@ -94,7 +94,7 @@ ROL_MODEL
 	lowerDiameter = 10.3
 	minVerticalScale = 0.5
 	maxVerticalScale = 3
-	mass = 9.474
+	mass = 3.493
 	cost = 5783
 	height = 5.6
 	volume = 0


### PR DESCRIPTION
-S-IVB interstage:
Mass: 7'700-lb or 3'493-kg, according to [https://web.archive.org/web/20051221114641/http://history.msfc.nasa.gov/saturn_apollo/documents/Third_Stage.pdf](url)


Deriving the rest, based on the original S-II interstage, which weighs 11'664-lb or 4'990 kg and is 18 feet = 5.5 meter high.
[https://history.nasa.gov/afj/ap10fj/as10-prep.html](url)
[https://web.archive.org/web/20090327003239/http://history.msfc.nasa.gov:80/saturn_apollo/documents/Second_Stage.pdf](url)

-MS-II-interstage: having the same measurements as S-II interstage should weigh similar. Giving it 5% more mass, because of its increase in carry-weight would be on the save side. ~ 5.24 tons

-MS-II-2-Interstage: height adjustment based on MS-II: 5'239.5 kg / 5.5 m * 6.5 m = 6'192 kg

-MS-V: slighly larger diameter then MS-II-2... so ≈ 6.4 t maybe

-STS Core & Booster: length adjustment also based on MS-II: 5'239.5 kg / 5.5 m * 8 m = 7'621 kg