### PR TITLE
Initial Chaka Monkey ROTank support

### DIFF
--- a/GameData/ROTanks/Compatibility/CMES/CMES-ModelData.cfg
+++ b/GameData/ROTanks/Compatibility/CMES/CMES-ModelData.cfg
@@ -1,0 +1,201 @@
+//
+// Core Tanks
+//
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-cbc
+	title = CBC
+	// oddly, this isn't a _whole_ cbc model, it's missing the upper orange bit (the LOX tank?)
+	modelName = CMES/Propulsion/CHAKA-CBC/model
+	diameter = 1.25
+	height = 6
+	volume = 7.36
+	minVerticalScale = 0.1
+	maxVerticalScale = 2
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-foam2
+	title = Short 3
+	modelName = CMES/Propulsion/NOVA-CHAKA-TANK-FOAM2/model
+	diameter = 5
+	height = 3
+	volume = 58.9
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-ius-lower
+	title = Round
+	modelName = CMES/Propulsion/IUS_Lower_Tank/model
+	diameter = 2.5
+	height = 1.97
+	volume = 7.05
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-ius3
+	title = Short 1
+	modelName = CMES/Propulsion/NOVA-CHAKA-TANK-IUS3/model
+	diameter = 5
+	height = 3
+	volume = 58.9
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-ius2
+	title = Short 2
+	modelName = CMES/Propulsion/NOVA-CHAKA-TANK-IUS2/model
+	diameter = 5
+	height = 3
+	volume = 58.9
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-2x1
+	title = Round 2
+	modelName = CMES/Propulsion/KW-AMLV-CORE/KW_Fuel_2mL0_5
+	diameter = 2
+	height = 1
+	volume = 2.54
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-2x4
+	title = Long
+	modelName = CMES/Propulsion/KW-AMLV-CORE/KW_Fuel_2mL2
+	diameter = 2
+	height = 4
+	volume = 12.6
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-foam-white
+	title = Short 4
+	modelName = CMES/Propulsion/NOVA-CHAKA-TANK-FOAMWHITE/model
+	diameter = 5
+	height = 3
+	volume = 58.9
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-talus
+	title = EUS
+	modelName = CMES/Propulsion/TALUS/TALUS
+	upperDiameter = 7.2
+	lowerDiameter = 4.8
+	height = 12.2
+	volume = 290 // very rough eyeball
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-mtv-x3
+	title = Short 5
+	modelName = CMES/Propulsion/NOVA-CHAKA-TANK-MTV-X3/model
+	diameter = 5
+	height = 3
+	volume = 58.9
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-mtv-x4
+	title = Short 6
+	modelName = CMES/Propulsion/NOVA-CHAKA-TANK-MTV-X4/model
+	diameter = 5
+	height = 3
+	volume = 58.9
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-mtv-x6
+	title = Long 2
+	modelName = CMES/Propulsion/NOVA-CHAKA-TANK-MTV-X6-orange/model
+	diameter = 5
+	height = 6.1
+	volume = 120
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-drto
+	title = Long 3
+	modelName = CMES/Propulsion/DRTO/model
+	diameter = 5
+	height = 6.1
+	volume = 120
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-adapter-1
+	title = Adapter 1
+	modelName = CMES/Propulsion/NP_interstage_1_25m_2_5m_tank2/model
+	upperDiameter = 1.25
+	lowerDiameter = 2.5
+	diameter = 2.5
+	height = 2
+	volume = 5.74
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-adapter-2
+	title = Adapter 2
+	modelName = CMES/Propulsion/ADVANCED-INTERTANK/model
+	upperDiameter = 3.75
+	lowerDiameter = 5
+	height = 3
+	volume = 44.9
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-adapter-3
+	title = Adapter 3
+	modelName = CMES/Propulsion/NP_interstage_5m_8m_tank/model
+	upperDiameter = 3.75
+	lowerDiameter = 5
+	height = 3
+	volume = 44.9
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-solar
+	title = Short 7
+	modelName = CMES/Propulsion/NOVA-CHAKA-TANK-SOLAR/model
+	diameter = 5
+	height = 3
+	volume = 58.9
+}
+
+ROL_MODEL:NEEDS[CMES]
+{
+	name = cmes-tank-truss
+	title = Truss
+	modelName = CMES/Structural/trusslrg_argon/trusslrg_argon
+	diameter = 2.5
+	height = 4.5
+	volume = 13.2 // 4 1x4.2 cylinders
+}
+
+@ROL_MODEL[cmes-tank-*]
+{
+	&style = Normal-Tank
+	&orientation = CENTRAL
+	&mass = 0
+	&cost = 0
+	&minVerticalScale = 0.2
+	&maxVerticalScale = 5
+}

--- a/GameData/ROTanks/Compatibility/CMES/CMES-Tank.cfg
+++ b/GameData/ROTanks/Compatibility/CMES/CMES-Tank.cfg
@@ -1,0 +1,49 @@
+PART:NEEDS[CMES]
+{
+	name = ROT-CMES-Tank
+	title = CMES Modular Tank
+	rotanksApplyDefaults = true
+}
+
+@PART[ROT-CMES-Tank]:AFTER[a_ROTanks]
+{
+	@tags = #$tags$, cmes, chaka
+	@MODULE[ModuleROTank]
+	{
+		@currentVariant = Long
+		@currentCore = cmes-tank-cbc
+
+		CORE
+		{
+			variant = Long
+			model = cmes-tank-cbc
+			model = cmes-tank-2x4
+			model = cmes-tank-mtv-x6
+			model = cmes-tank-drto
+		}
+
+		CORE
+		{
+			variant = Short
+			model = cmes-tank-ius3
+			model = cmes-tank-ius2
+			model = cmes-tank-foam2
+			model = cmes-tank-foam-white
+			model = cmes-tank-mtv-x3
+			model = cmes-tank-mtv-x4
+			model = cmes-tank-solar
+		}
+
+		CORE
+		{
+			variant = Misc
+			model = cmes-tank-talus
+			model = cmes-tank-ius-lower
+			model = cmes-tank-2x1
+			model = cmes-tank-adapter-1
+			model = cmes-tank-adapter-2
+			model = cmes-tank-adapter-3
+			model = cmes-tank-truss
+		}
+	}
+}

--- a/GameData/ROTanks/Compatibility/reDIRECT-Tank.cfg
+++ b/GameData/ROTanks/Compatibility/reDIRECT-Tank.cfg
@@ -1,133 +1,16 @@
-//	===========================================================================
-//	All work here was originally from Shadowmage and SSTU. I have adapted their
-//	work to be more usable for our purposes in Realism Overhaul, but all credit
-//	should be given to Shadowmage for the great work!
-//	===========================================================================
-
 PART:NEEDS[reDIRECT]
 {
-	module = Part
 	name = ROT-reDIRECTTank
-	author = Shadowmage, Pap
-
-	//  ============================================================================
-	//  Model and Dimensions
-	//  ============================================================================
-
-	MODEL
-	{
-		model = ROLib/Assets/EmptyProxyModel
-	}
-
-	scale = 1.0
-	rescaleFactor = 1.0
-
-	node_stack_top 				= 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 2
-	node_stack_bottom 			= 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 2
-	node_stack_noseinterstage 	= 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 2
-	node_stack_mountinterstage	= 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 2
-	node_attach					= 2.5, 0.0, 0.0, 1.0, 0.0, 0.0, 0
-
-	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
-	attachRules = 1,1,1,1,0
-
-	//  ============================================================================
-	//  Title, Description, Category, Techs
-	//  ============================================================================
-
 	title = reDIRECT Modular Tank
-	manufacturer = Generic
-	description = This modular tank allows for many customizations. You can integrate top and bottom adapters, adjust the length and the diameter as well. It is comprised of many different tank types. You can choose the tank type below. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. The HP versions of the tanks are Highly Pressurized and are used for engines that require it.
-
-	tags = fuel, tank, modular, proc, procedural, redirect
-
-	mass = 1.0
-
-	category = FuelTank
-
-	TechRequired = unlockParts
-	cost = 150
-	entryCost = 1
-
-	//  ============================================================================
-	//	DO NOT CHANGE (Normally)
-	//  ============================================================================
-
-	maxTemp = 773.15
-	skinMaxTemp = 873.15
-	crashTolerance = 10
-	breakingForce = 250
-	breakingTorque = 250
-	fuelCrossFeed = true
-	subcategory = 0
-	emissiveConstant = 0.85
-	thermalMassModifier = 1.0
-	skinMassPerArea = 2.0
-	buoyancy = 0.95
-
-	//  ============================================================================
-	//  Modules and Resources
-	//  ============================================================================
-
-	MODULE
+	rotanksApplyDefaults = true
+}
+@PART[ROT-reDIRECTTank]:AFTER[a_ROTanks]
+{
+	@tags = #$tags$, redirect
+	@MODULE[ModuleROTank]
 	{
-		name = ModuleFuelTanks
-		volume = 556
-		utilizationTweakable = true
-		type = Default
-		typeAvailable = Default
-		typeAvailable = Structural
-		typeAvailable = Fuselage
-	}
-
-	MODULE
-	{
-		name = ModuleROTank
-
-		// Dimension Settings
-		diameterLargeStep = 1.0
-		diameterSmallStep = 0.1
-		diameterSlideStep = 0.001
-		minDiameter = 0.1
-		maxDiameter = 50.0
-		minLength = 0.1
-		maxLength = 50.0
-
-		// Adapter Settings
-		useAdapterMass = false
-		useAdapterCost = false
-
-		// Attach Node Settings
-		topNodeName = top
-		bottomNodeName = bottom
-		noseNodeNames = none
-		coreNodeNames = none
-		mountNodeNames = none
-		topInterstageNodeName = noseinterstage
-		bottomInterstageNodeName = mountinterstage
-
-		// Fairing Settings
-		topFairingIndex = -1
-		bottomFairingIndex = -1
-		centralFairingIndex = -1
-
-		// Default Values
-		currentDiameter = 5.0
-		currentLength = 5.0
-		currentVariant = SLS
-		currentNose = Model-None
-		currentCore = reSTOCK-SLS-Tank
-		currentMount = Model-None
-		currentNoseTexture = default
-		currentCoreTexture = default
-		currentMountTexture = default
-
-		// Model Handling
-		lengthWidth = false
-		validateNose = true
-		validateMount = true
-		hasNoseToRotate = true
-		hasMountToRotate = true
+		@currentVariant = SLS
+		@currentCore = reSTOCK-SLS-Tank
 
 		CORE
 		{
@@ -147,11 +30,8 @@ PART:NEEDS[reDIRECT]
 			model = reSTOCK-Shuttle-Tank
 		}
 
-		NOSE
+		@NOSE
 		{
-			// Generic
-			model = Model-None
-			
 			// reDIRECT Nose
 			model = reSTOCK-Jupiter-Tank
 			model = reSTOCK-Jupiter-Adapter
@@ -161,234 +41,16 @@ PART:NEEDS[reDIRECT]
 			model = reSTOCK-Ares-Adapter
 			model = reSTOCK-Ares-Adapter-2
 			model = reSTOCK-Shuttle-Nose
-
-			// Nosecones
-			model = Nosecone-1
-			model = Nosecone-2
-			model = Nosecone-3
-			model = Nosecone-4
-			model = Nosecone-5
-			model = Nosecone-6
-			model = Nosecone-7
-			model = Nosecone-8
-			model = Nosecone-9
-			model = Nosecone-10
-			model = Nosecone-11
-			model = Nosecone-12
-			model = Nosecone-13
-
-			// Domes
-			model = Adapter-Dome-A
-			model = Adapter-Dome-B
-			model = Adapter-Dome-Flat
-			model = Adapter-Dome-Half
-			model = Adapter-Dome-Half-Framed-S
-			model = Adapter-Dome-Half-Framed-M
-
-			// Adapters
-			model = Adapter-2-1-Flat
-			model = Adapter-2-1-Short
-			model = Adapter-2-1-Long
-			model = Adapter-3-1-Flat
-			model = Adapter-3-1-Short
-			model = Adapter-3-1-Long
-			model = Adapter-3-1-Extended
-			model = Adapter-3-2-Flat
-			model = Adapter-3-2-Short
-			model = Adapter-3-2-Long
-			model = Adapter-3-2-Extended
-			model = Adapter-4-1-Flat
-			model = Adapter-4-1-Short
-			model = Adapter-4-3-Flat
-			model = Adapter-4-3-Short
-			model = Adapter-4-3-Long
-
-			// Inverted Adapters
-			model = Adapter-1-2-Flat
-			model = Adapter-1-2-Short
-			model = Adapter-1-2-Long
-			model = Adapter-1-3-Flat
-			model = Adapter-1-3-Short
-			model = Adapter-1-3-Long
-			model = Adapter-2-3-Flat
-			model = Adapter-2-3-Short
-			model = Adapter-2-3-Long
-			model = Adapter-3-4-Flat
-			model = Adapter-3-4-Short
-			model = Adapter-3-4-Long
-
-			// Soyuz
-			model = Adapter-Soyuz
-			model = Adapter-R7
-			model = Adapter-Soyuz-S
-			model = Adapter-Soyuz-M
-			model = Adapter-Soyuz-L
-			model = Adapter-Soyuz-XL
-
-			// Split
-			model = Intertank-Split
-			model = Intertank-Sphere
 		}
 
-		MOUNT
+		@MOUNT
 		{
-			// Generic
-			model = Model-None
-			
 			// reDIRECT Mount
 			model = reSTOCK-Jupiter-Mount
 			model = reSTOCK-Jupiter-US-Mount
 			model = reSTOCK-SLS-Mount
 			model = reSTOCK-Ares-US-Mount
 			model = reSTOCK-Shuttle-End-Cap
-			
-			// reDIRECT Nose
-			model = reSTOCK-Jupiter-Tank
-			model = reSTOCK-Jupiter-Adapter
-			model = reSTOCK-Jupiter-US-Tank
-			model = reSTOCK-SLS-Tank-Short
-			model = reSTOCK-Ares-US-Tank
-			model = reSTOCK-Ares-Adapter
-			model = reSTOCK-Ares-Adapter-2
-			model = reSTOCK-Shuttle-Nose
-
-			// Engine Mounts
-			model = Mount-S-IC
-			model = Mount-S-IC-45
-			model = Mount-S-II
-			model = Mount-S-IVB
-			model = Mount-Generic
-			model = Mount-Boattail
-			model = Mount-Shroud-Tight
-			model = Mount-Shroud-S
-			model = Mount-Shroud-M
-			model = Mount-Shroud-L
-			model = Mount-Shroud-XL
-			model = Mount-SLS
-			model = Mount-SLS-6
-			model = Mount-Pyrios
-			model = Mount-Nova
-			model = Mount-Direct
-			model = Mount-Delta-IV
-			model = Mount-RD-107
-			model = Mount-RD-108
-			model = Mount-RD-108-45
-			model = Mount-Skeletal-S
-			model = Mount-Skeletal-M
-			model = Mount-Skeletal-L
-			
-			// BDB Mounts
-			model = Mount-BDB-LDC-Single
-			model = Mount-BDB-LDC-Dual
-			model = Mount-BDB-LDC-Quad
-			model = Mount-BDB-LDC-x7
-			model = Mount-BDB-LDC-25Adapter
-			model = Mount-BDB-LDC-375Adapter
-			model = Mount-BDB-CentaurD
-			model = Mount-BDB-CentaurV
-			model = Mount-BDB-Saturn-SII
-			model = Mount-BDB-Saturn-SII-7X
-			
-			// Hephaistos
-			model = Mount-Hephaistos-Vulcan
-
-			// Domes
-			model = Atlas-Mount
-			model = Adapter-Dome-A
-			model = Adapter-Dome-B
-			model = Adapter-Dome-Flat
-			model = Adapter-Dome-Half
-			model = Adapter-Dome-Half-Framed-S
-			model = Adapter-Dome-Half-Framed-M
-
-			// Adapters
-			model = Adapter-2-1-Flat
-			model = Adapter-2-1-Short
-			model = Adapter-2-1-Long
-			model = Adapter-3-1-Flat
-			model = Adapter-3-1-Short
-			model = Adapter-3-1-Long
-			model = Adapter-3-1-Extended
-			model = Adapter-3-2-Flat
-			model = Adapter-3-2-Short
-			model = Adapter-3-2-Long
-			model = Adapter-3-2-Extended
-			model = Adapter-4-1-Flat
-			model = Adapter-4-1-Short
-			model = Adapter-4-3-Flat
-			model = Adapter-4-3-Short
-			model = Adapter-4-3-Long
-
-			// Inverted Adapters
-			model = Adapter-1-2-Flat
-			model = Adapter-1-2-Short
-			model = Adapter-1-2-Long
-			model = Adapter-1-3-Flat
-			model = Adapter-1-3-Short
-			model = Adapter-1-3-Long
-			model = Adapter-2-3-Flat
-			model = Adapter-2-3-Short
-			model = Adapter-2-3-Long
-			model = Adapter-3-4-Flat
-			model = Adapter-3-4-Short
-			model = Adapter-3-4-Long
-
-			// Soyuz
-			model = Adapter-Soyuz-S-BOT
-			model = Adapter-Soyuz-M-BOT
-			model = Adapter-Soyuz-L-BOT
-			model = Adapter-Soyuz-XL-BOT
-
-			// Split
-			model = Intertank-Split
-			model = Intertank-Sphere
-
-			// Nosecones
-			model = Nosecone-1
-			model = Nosecone-2
-			model = Nosecone-3
-			model = Nosecone-4
-			model = Nosecone-5
-			model = Nosecone-6
-			model = Nosecone-7
-			model = Nosecone-8
-			model = Nosecone-9
-			model = Nosecone-10
-			model = Nosecone-11
-			model = Nosecone-12
-			model = Nosecone-13
 		}
-	}
-
-	MODULE
-	{
-		name = ROLSelectableNodes
-		nodeName = noseinterstage
-		startsEnabled = false
-	}
-
-	MODULE
-	{
-		name = ROLSelectableNodes
-		nodeName = mountinterstage
-		startsEnabled = false
-	}
-
-	MODULE
-	{
-		name = ModuleToggleCrossfeed
-		toggleFlight = true
-		toggleEditor = true
-		crossfeedStatus = true
-	}
-
-	MODULE
-	{
-		name = SSTURecolorGUI
-	}
-
-	MODULE
-	{
-		name = ROLCollisionHandler
 	}
 }

--- a/GameData/ROTanks/Parts/rotanks-defaults.cfg
+++ b/GameData/ROTanks/Parts/rotanks-defaults.cfg
@@ -1,0 +1,362 @@
+// Fills in common bits shared by many ROTanks tanks.
+//
+// Usage:
+// PART:NEEDS[something] {
+//  name = blah
+//  title = blah
+//  rotanksApplyDefaults = true
+// }
+// @PART[blah]:AFTER[a_ROTanks]
+// {
+//    @MODULE[ModuleROTanks] {
+//      @currentVariant = ...
+//      @currentCore = ...
+//      CORE {...}
+//      @NOSE {any overrides}
+//      @MOUNT {any overrides}
+// }}
+
+
+@PART:HAS[#rotanksApplyDefaults]:FOR[a_ROTanks] // MUST run BEFORE BEFORE[RealismOverhaul]!
+{
+	module = Part
+	author = Shadowmage, Pap, etc
+
+	//  ============================================================================
+	//  Model and Dimensions
+	//  ============================================================================
+
+	MODEL
+	{
+		model = ROLib/Assets/EmptyProxyModel
+	}
+
+	scale = 1.0
+	rescaleFactor = 1.0
+
+	node_stack_top 				= 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom 			= 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 2
+	node_stack_noseinterstage 	= 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_mountinterstage	= 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 2
+	node_attach					= 2.5, 0.0, 0.0, 1.0, 0.0, 0.0, 0
+
+	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+	attachRules = 1,1,1,1,0
+
+	//  ============================================================================
+	//  Title, Description, Category, Techs
+	//  ============================================================================
+
+	manufacturer = Generic
+	description = This modular tank allows for many customizations. You can integrate top and bottom adapters, adjust the length and the diameter as well. It is comprised of many different tank types. You can choose the tank type below. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. The HP versions of the tanks are Highly Pressurized and are used for engines that require it.
+
+	tags = fuel, tank, modular, proc, procedural
+
+	mass = 1.0
+
+	category = FuelTank
+
+	TechRequired = unlockParts
+	cost = 150
+	entryCost = 1
+
+	//  ============================================================================
+	//	DO NOT CHANGE (Normally)
+	//  ============================================================================
+
+	maxTemp = 773.15
+	skinMaxTemp = 873.15
+	crashTolerance = 10
+	breakingForce = 250
+	breakingTorque = 250
+	fuelCrossFeed = true
+	subcategory = 0
+	emissiveConstant = 0.85
+	thermalMassModifier = 1.0
+	skinMassPerArea = 2.0
+	buoyancy = 0.95
+
+	//  ============================================================================
+	//  Modules and Resources
+	//  ============================================================================
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 556
+		utilizationTweakable = true
+		type = Default
+		typeAvailable = Default
+		typeAvailable = Structural
+		typeAvailable = Fuselage
+	}
+
+	MODULE
+	{
+		name = ModuleROTank
+
+		// Dimension Settings
+		diameterLargeStep = 1.0
+		diameterSmallStep = 0.1
+		diameterSlideStep = 0.001
+		minDiameter = 0.1
+		maxDiameter = 50.0
+		minLength = 0.1
+		maxLength = 50.0
+
+		// Adapter Settings
+		useAdapterMass = false
+		useAdapterCost = false
+
+		// Attach Node Settings
+		topNodeName = top
+		bottomNodeName = bottom
+		noseNodeNames = none
+		coreNodeNames = none
+		mountNodeNames = none
+		topInterstageNodeName = noseinterstage
+		bottomInterstageNodeName = mountinterstage
+
+		// Fairing Settings
+		topFairingIndex = -1
+		bottomFairingIndex = -1
+		centralFairingIndex = -1
+
+		// Default Values
+		currentDiameter = 5.0
+		currentLength = 5.0
+		currentVariant = TBD
+		currentNose = Model-None
+		currentCore = TBD
+		currentMount = Model-None
+		currentNoseTexture = default
+		currentCoreTexture = default
+		currentMountTexture = default
+
+		// Model Handling
+		lengthWidth = false
+		validateNose = true
+		validateMount = true
+		hasNoseToRotate = true
+		hasMountToRotate = true
+
+		NOSE
+		{
+			// Generic
+			model = Model-None
+			
+			// Nosecones
+			model = Nosecone-1
+			model = Nosecone-2
+			model = Nosecone-3
+			model = Nosecone-4
+			model = Nosecone-5
+			model = Nosecone-6
+			model = Nosecone-7
+			model = Nosecone-8
+			model = Nosecone-9
+			model = Nosecone-10
+			model = Nosecone-11
+			model = Nosecone-12
+			model = Nosecone-13
+
+			// Domes
+			model = Adapter-Dome-A
+			model = Adapter-Dome-B
+			model = Adapter-Dome-Flat
+			model = Adapter-Dome-Half
+			model = Adapter-Dome-Half-Framed-S
+			model = Adapter-Dome-Half-Framed-M
+
+			// Adapters
+			model = Adapter-2-1-Flat
+			model = Adapter-2-1-Short
+			model = Adapter-2-1-Long
+			model = Adapter-3-1-Flat
+			model = Adapter-3-1-Short
+			model = Adapter-3-1-Long
+			model = Adapter-3-1-Extended
+			model = Adapter-3-2-Flat
+			model = Adapter-3-2-Short
+			model = Adapter-3-2-Long
+			model = Adapter-3-2-Extended
+			model = Adapter-4-1-Flat
+			model = Adapter-4-1-Short
+			model = Adapter-4-3-Flat
+			model = Adapter-4-3-Short
+			model = Adapter-4-3-Long
+
+			// Inverted Adapters
+			model = Adapter-1-2-Flat
+			model = Adapter-1-2-Short
+			model = Adapter-1-2-Long
+			model = Adapter-1-3-Flat
+			model = Adapter-1-3-Short
+			model = Adapter-1-3-Long
+			model = Adapter-2-3-Flat
+			model = Adapter-2-3-Short
+			model = Adapter-2-3-Long
+			model = Adapter-3-4-Flat
+			model = Adapter-3-4-Short
+			model = Adapter-3-4-Long
+
+			// Soyuz
+			model = Adapter-Soyuz
+			model = Adapter-R7
+			model = Adapter-Soyuz-S
+			model = Adapter-Soyuz-M
+			model = Adapter-Soyuz-L
+			model = Adapter-Soyuz-XL
+
+			// Split
+			model = Intertank-Split
+			model = Intertank-Sphere
+		}
+
+		MOUNT
+		{
+			// Generic
+			model = Model-None
+			
+			// Engine Mounts
+			model = Mount-S-IC
+			model = Mount-S-IC-45
+			model = Mount-S-II
+			model = Mount-S-IVB
+			model = Mount-Generic
+			model = Mount-Boattail
+			model = Mount-Shroud-Tight
+			model = Mount-Shroud-S
+			model = Mount-Shroud-M
+			model = Mount-Shroud-L
+			model = Mount-Shroud-XL
+			model = Mount-SLS
+			model = Mount-SLS-6
+			model = Mount-Pyrios
+			model = Mount-Nova
+			model = Mount-Direct
+			model = Mount-Delta-IV
+			model = Mount-RD-107
+			model = Mount-RD-108
+			model = Mount-RD-108-45
+			model = Mount-Skeletal-S
+			model = Mount-Skeletal-M
+			model = Mount-Skeletal-L
+			
+			// BDB Mounts
+			model = Mount-BDB-LDC-Single
+			model = Mount-BDB-LDC-Dual
+			model = Mount-BDB-LDC-Quad
+			model = Mount-BDB-LDC-x7
+			model = Mount-BDB-LDC-25Adapter
+			model = Mount-BDB-LDC-375Adapter
+			model = Mount-BDB-CentaurD
+			model = Mount-BDB-CentaurV
+			model = Mount-BDB-Saturn-SII
+			model = Mount-BDB-Saturn-SII-7X
+			
+			// Hephaistos
+			model = Mount-Hephaistos-Vulcan
+
+			// Domes
+			model = Atlas-Mount
+			model = Adapter-Dome-A
+			model = Adapter-Dome-B
+			model = Adapter-Dome-Flat
+			model = Adapter-Dome-Half
+			model = Adapter-Dome-Half-Framed-S
+			model = Adapter-Dome-Half-Framed-M
+
+			// Adapters
+			model = Adapter-2-1-Flat
+			model = Adapter-2-1-Short
+			model = Adapter-2-1-Long
+			model = Adapter-3-1-Flat
+			model = Adapter-3-1-Short
+			model = Adapter-3-1-Long
+			model = Adapter-3-1-Extended
+			model = Adapter-3-2-Flat
+			model = Adapter-3-2-Short
+			model = Adapter-3-2-Long
+			model = Adapter-3-2-Extended
+			model = Adapter-4-1-Flat
+			model = Adapter-4-1-Short
+			model = Adapter-4-3-Flat
+			model = Adapter-4-3-Short
+			model = Adapter-4-3-Long
+
+			// Inverted Adapters
+			model = Adapter-1-2-Flat
+			model = Adapter-1-2-Short
+			model = Adapter-1-2-Long
+			model = Adapter-1-3-Flat
+			model = Adapter-1-3-Short
+			model = Adapter-1-3-Long
+			model = Adapter-2-3-Flat
+			model = Adapter-2-3-Short
+			model = Adapter-2-3-Long
+			model = Adapter-3-4-Flat
+			model = Adapter-3-4-Short
+			model = Adapter-3-4-Long
+
+			// Soyuz
+			model = Adapter-Soyuz-S-BOT
+			model = Adapter-Soyuz-M-BOT
+			model = Adapter-Soyuz-L-BOT
+			model = Adapter-Soyuz-XL-BOT
+
+			// Split
+			model = Intertank-Split
+			model = Intertank-Sphere
+
+			// Nosecones
+			model = Nosecone-1
+			model = Nosecone-2
+			model = Nosecone-3
+			model = Nosecone-4
+			model = Nosecone-5
+			model = Nosecone-6
+			model = Nosecone-7
+			model = Nosecone-8
+			model = Nosecone-9
+			model = Nosecone-10
+			model = Nosecone-11
+			model = Nosecone-12
+			model = Nosecone-13
+		}
+	}
+
+	MODULE
+	{
+		name = ROLSelectableNodes
+		nodeName = noseinterstage
+		startsEnabled = false
+	}
+
+	MODULE
+	{
+		name = ROLSelectableNodes
+		nodeName = mountinterstage
+		startsEnabled = false
+	}
+
+	MODULE
+	{
+		name = ModuleToggleCrossfeed
+		toggleFlight = true
+		toggleEditor = true
+		crossfeedStatus = true
+	}
+
+	MODULE
+	{
+		name = SSTURecolorGUI
+	}
+
+	MODULE
+	{
+		name = ROLCollisionHandler
+	}
+
+	!rotanksApplyDefaults = delete
+}


### PR DESCRIPTION
As a separate part, following reDirect's lead.
Covers most tank models, one Core for each.
A number of CMES tank parts are actually multiple models combined;
could have used SUBMODELs to do the same, didn't.

With some refactoring to avoid copy-pasting everything from
the reDirect part. Could probably be used by other parts
outside the Compatibility folder, presumably with some tweaking.

There's about 30 tank parts, evenly split between non-RO, ro-yes-but-rp1-no, rp1-nocost and fully configured. I've come around to Pap's way of thinking; adding things to ROTanks is the most effective way to get configs that are consistent with the rest.