### PR TITLE
ROT-Misc-Tank: an ROTank for stock, restock, etc models

### DIFF
--- a/GameData/ROTanks/Compatibility/ROTanks.restockwhitelist
+++ b/GameData/ROTanks/Compatibility/ROTanks.restockwhitelist
@@ -1,1 +1,3 @@
 Squad/Parts/FuelTank/FoilTanks/
+Squad/Parts/FuelTank/
+Squad/Parts/Resources/

--- a/GameData/ROTanks/Compatibility/misc/Misc-Tank.cfg
+++ b/GameData/ROTanks/Compatibility/misc/Misc-Tank.cfg
@@ -1,0 +1,316 @@
+// ROT-MiscTank: a single part for all the ROL_MODEL cores from Misc/*.cfg
+// Because it's more manageable than 1 part per source mod, especially when
+// RO turns each part into 4 parts (sep, int, balloon, shielded)
+PART
+{
+	name = ROT-MiscTank
+	title = Another Modular Tank
+	rotanksApplyDefaults = true
+	wantROTankTypes = fuel balloon sm shielded
+}
+
+// ROT-MiscTank-Radial: same, but for models that only make sense to
+// surface-attach
+PART
+{
+	name = ROT-MiscTank-Radial
+	title = Another Modular Radial Tank
+	rotanksApplyDefaults = true
+	wantROTankTypes = fuel
+}
+
+// TODO: consider moving each mod's CORE{} to each mod's own file, with
+//  something like a addBlahCores = true mechanism?
+//  Make it easier to later include them in dedicated parts without copy-paste
+
+@PART[ROT-MiscTank]:AFTER[a_ROTanks]
+{
+	@description = A basic ROTanks tank exposing a bunch of models from other mods currently installed. Stock, ReStock, Vens, etc.
+	@MODULE[ModuleROTank]
+	{
+		@currentDiameter = 3
+		@currentVariant = Squad
+		@currentCore = rotanks-squad-tank-flt800
+
+		CORE:NEEDS[Squad]
+		{
+			variant = Squad
+			model = rotanks-squad-tank-flt800
+			model = rotanks-squad-tank-flt400
+			model = rotanks-squad-tank-flt200
+			model = rotanks-squad-tank-flt100
+			model = rotanks-squad-tank-size1-size2
+			model = rotanks-squad-tank-size1-size2-slant
+			model = rotanks-squad-tank-rocko-1
+			model = rotanks-squad-tank-rocko-1b
+			model = rotanks-squad-tank-rocko-2
+			model = rotanks-squad-tank-rocko-3
+			model = rotanks-squad-tank-rocko-3b
+			model = rotanks-squad-tank-rocko-3c
+			model = rotanks-squad-tank-rocko-4
+			model = rotanks-squad-tank-rocko-4b
+			model = rotanks-squad-tank-kerbo-1
+			model = rotanks-squad-tank-kerbo-2
+			model = rotanks-squad-tank-kerbo-3
+			model = rotanks-squad-tank-rcs-1
+			model = rotanks-squad-tank-rcs-2
+			model = rotanks-squad-tank-rcs-3
+			model = rotanks-squad-tank-oscar-b
+			model = rotanks-squad-tank-xenon-small
+			model = rotanks-squad-tank-xenon-large
+		}
+		CORE:NEEDS[Squad]
+		{
+			variant = Squad Mk2
+			model = rotanks-squad-tank-mk2-short-1
+			model = rotanks-squad-tank-mk2-short-2
+			model = rotanks-squad-tank-mk2-short-3
+			model = rotanks-squad-tank-mk2-long-1
+			model = rotanks-squad-tank-mk2-long-2
+			model = rotanks-squad-tank-mk2-adapter-1
+			model = rotanks-squad-tank-mk2-adapter-2
+			model = rotanks-squad-tank-mk2-adapter-3
+			model = rotanks-squad-tank-mk2-adapter-4
+		}
+		CORE:NEEDS[Squad]
+		{
+			variant = Squad Mk3
+			model = rotanks-squad-tank-mk3-mono
+			model = rotanks-squad-tank-mk3-short-1
+			model = rotanks-squad-tank-mk3-short-2
+			model = rotanks-squad-tank-mk3-medium-1
+			model = rotanks-squad-tank-mk3-medium-2
+			model = rotanks-squad-tank-mk3-long-1
+			model = rotanks-squad-tank-mk3-long-2
+			model = rotanks-squad-tank-mk3-adapter-mk2
+			model = rotanks-squad-tank-mk3-adapter-size2
+			model = rotanks-squad-tank-mk3-adapter-size2-slant
+			model = rotanks-squad-tank-mk3-adapter-size3
+			model = rotanks-squad-tank-mk3-adapter-shuttle
+		}
+		CORE:NEEDS[ReStock]
+		{
+			variant = ReStock
+			model = rotanks-restock-tank-oscar-a
+			model = rotanks-restock-tank-oscar-a-2
+			model = rotanks-restock-tank-oscar-b
+			model = rotanks-restock-tank-oscar-b-2
+			model = rotanks-restock-tank-oscar-c
+			model = rotanks-restock-tank-oscar-c-2
+			model = rotanks-restock-tank-oscar-d
+			model = rotanks-restock-tank-oscar-d-2
+			model = rotanks-restock-tank-oscar-e
+			model = rotanks-restock-tank-oscar-e-2
+			model = rotanks-restock-tank-flt100
+			model = rotanks-restock-tank-flt200
+			model = rotanks-restock-tank-flt400
+			model = rotanks-restock-tank-flt800
+			model = rotanks-restock-tank-1875-1-1
+			model = rotanks-restock-tank-1875-1-2
+			model = rotanks-restock-tank-1875-1-3
+			model = rotanks-restock-tank-1875-2-1
+			model = rotanks-restock-tank-1875-2-2
+			model = rotanks-restock-tank-1875-2-3
+			model = rotanks-restock-tank-1875-3-1
+			model = rotanks-restock-tank-1875-3-2
+			model = rotanks-restock-tank-1875-3-3
+			model = rotanks-restock-tank-1875-4-1
+			model = rotanks-restock-tank-1875-4-2
+			model = rotanks-restock-tank-1875-4-3
+			model = rotanks-restock-tank-375-1
+			model = rotanks-restock-tank-375-1-2
+			model = rotanks-restock-tank-375-2
+			model = rotanks-restock-tank-375-2-2
+			model = rotanks-restock-tank-375-3
+			model = rotanks-restock-tank-375-3-2
+			model = rotanks-restock-tank-375-4
+			model = rotanks-restock-tank-375-4-2
+			model = rotanks-restock-tank-siv-64k
+			model = rotanks-restock-tank-siv-64k-2
+			model = rotanks-restock-tank-siv-128k
+			model = rotanks-restock-tank-siv-128k-2
+			model = rotanks-restock-tank-siv-256k
+			model = rotanks-restock-tank-siv-256k-2
+			model = rotanks-restock-tank-siv-512k
+			model = rotanks-restock-tank-siv-512k-2
+		}
+		CORE:NEEDS[ReStockPlus]
+		{
+			variant = ReStockPlus
+			model = rotanks-restockplus-tank-probe-1
+			model = rotanks-restockplus-tank-probe-2
+		}
+		CORE:NEEDS[VenStockRevamp]
+		{
+			variant = Ven's
+			model = rotanks-vens-tank-octo
+			model = rotanks-vens-tank-oscar-a
+			model = rotanks-vens-tank-oscar-c
+			model = rotanks-vens-tank-oscar-d
+			model = rotanks-vens-tank-soft-1
+			model = rotanks-vens-tank-soft-2
+			model = rotanks-vens-tank-soft-3
+			model = rotanks-vens-tank-soft-4
+			model = rotanks-vens-tank-soft-5
+			model = rotanks-vens-tank-rockomax-48
+		}
+
+		CORE:NEEDS[NearFutureExploration]
+		{
+			variant = NFEx Multi Large
+			_addNfexMaterials = withVariants
+			_nfexPrefix = rotanks-nfex-tank-multi-2
+		}
+		CORE:NEEDS[NearFutureExploration]
+		{
+			variant = NFEx Multi Med
+			_addNfexMaterials = withVariants
+			_nfexPrefix = rotanks-nfex-tank-multi-3
+		}
+		CORE:NEEDS[NearFutureExploration]
+		{
+			variant = NFEx Multi Short
+			_addNfexMaterials = withVariants
+			_nfexPrefix = rotanks-nfex-tank-multi-4
+		}
+		CORE:NEEDS[NearFutureExploration]
+		{
+			variant = NFEx Multi Tiny
+			_addNfexMaterials = true
+			_nfexPrefix = rotanks-nfex-tank-multi-1
+		}
+	}
+}
+
+@PART[ROT-MiscTank-Radial]:AFTER[a_ROTanks]
+{
+	@description = Like Another Modular Tanks, but for radial models
+	!node_stack_top = delete
+    !node_stack_bottom = delete
+    !node_stack_noseinterstage = delete
+    !node_stack_mountinterstage	= delete
+    @attachRules = 0,1,0,1,1
+
+	@tags ^= :$:, radial:
+
+	@MODULE[ModuleROTank]
+	{
+		@currentDiameter = 1
+		@currentVariant = Squad
+		@currentCore = rotanks-squad-tank-rcs-radial
+		// TODO: figure out which of these lines were needed to unbreak things
+		%validateNose = false
+		%validateMount = false
+		!hasNoseToRotate = delete
+		!hasMountToRotate = delete
+
+		CORE:NEEDS[Squad]
+		{
+			variant = Squad
+			model = rotanks-squad-tank-rcs-radial
+			model = rotanks-squad-tank-xenon-radial
+			model = rotanks-squad-tank-radial-round
+			model = rotanks-squad-tank-radial-capsule
+			model = rotanks-squad-tank-radial-ore
+		}
+		CORE:NEEDS[ReStock]
+		{
+			variant = ReStock
+			model = rotanks-restock-tank-radial-round
+			model = rotanks-restock-tank-radial-capsule
+			model = rotanks-restock-tank-rcs-radial-1
+			model = rotanks-restock-tank-rcs-radial-2
+			model = rotanks-restock-tank-rcs-radial-3
+			model = rotanks-restock-tank-xenon-radial
+			model = rotanks-restock-tank-goo-radial
+			model = rotanks-restock-tank-goo-radial-compact
+		}
+		CORE:NEEDS[NearFutureExploration]
+		{
+			variant = NFEx Large
+			_addNfexMaterials = true
+			_nfexPrefix = rotanks-nfex-tank-multi-5
+		}
+		CORE:NEEDS[NearFutureExploration]
+		{
+			variant = NFEx Med
+			_addNfexMaterials = true
+			_nfexPrefix = rotanks-nfex-tank-multi-6
+		}
+		CORE:NEEDS[NearFutureExploration]
+		{
+			variant = NFEx Short
+			_addNfexMaterials = true
+			_nfexPrefix = rotanks-nfex-tank-multi-7
+		}
+		CORE:NEEDS[NearFutureExploration]
+		{
+			variant = NFEx Tiny
+			_addNfexMaterials = true
+			_nfexPrefix = rotanks-nfex-tank-multi-8
+		}
+		!NOSE {}
+		!MOUNT {}
+		NOSE {
+			model = Model-None
+		}
+		MOUNT {
+			model = Model-None
+		}
+	}
+}
+
+@PART[ROT-MiscTank*]:AFTER[a_ROTanks]
+{
+	@MODULE[ModuleROTank]
+	{
+		@CORE:HAS[#_addNfexMaterials]
+		{
+			_nfexMaterial = gold
+			_nfexMaterial = silver
+			_nfexMaterial = metal
+			_nfexMaterial = rcs
+			_nfexMaterial = xe
+			_nfexMaterial = ar
+			_nfexMaterial = li
+		}
+	}
+}
+
+@PART[ROT-MiscTank*]:HAS[@MODULE[ModuleROTank]:HAS[@CORE:HAS[#_nfexMaterial]]]:AFTER[a_ROTanks]
+{
+	@MODULE[ModuleROTank]
+	{
+		@CORE:HAS[#_nfexMaterial,#_addNfexMaterials[withVariants]]
+		{
+			model = #$_nfexPrefix$-$_nfexMaterial$-bare
+			model = #$_nfexPrefix$-$_nfexMaterial$-struct
+			model = #$_nfexPrefix$-$_nfexMaterial$-stack
+			model = #$_nfexPrefix$-$_nfexMaterial$-compact
+			!_nfexMaterial,0 = delete
+		}
+		@CORE:HAS[#_nfexMaterial,#_addNfexMaterials[true]]
+		{
+			model = #$_nfexPrefix$-$_nfexMaterial$
+			!_nfexMaterial,0 = delete
+		}
+	}
+	MM_PATCH_LOOP {}
+}
+@PART[ROT-MiscTank*]:AFTER[a_ROTanks]
+{
+	@MODULE[ModuleROTank]
+	{
+		@CORE:HAS[#_addNfexMaterials]
+		{
+			!_addNfexMaterials = delete
+			!_nfexPrefix = delete
+		}
+	}
+}
+
+// temporary
+@PART[ROT-MiscTank*]
+{
+	%RP0conf = true
+}

--- a/GameData/ROTanks/Compatibility/misc/ModelDataUtils.cfg
+++ b/GameData/ROTanks/Compatibility/misc/ModelDataUtils.cfg
@@ -1,0 +1,55 @@
+// _rotanksApplyDefaults: a helper to fill in repetitive elements of a ROL_MODEL
+// intended for a ROTanks core tank.
+// Basic usage:
+// ROL_MODEL
+// {
+//    name = rotanks-xxx
+//    modelName = yyy
+//    diameter = nn // or both lowerDiameter and upperDiameter; default volume gets derived from this
+//    length = nn
+//    _rotanksApplyDefaults = true
+// }
+//
+// Runs in FOR[ROTanks]; avoids clobbering values already set.
+
+@ROL_MODEL[rotanks-*]:HAS[#_rotanksApplyDefaults,~upperDiameter]:FOR[ROTanks]
+{
+	&upperDiameter = #$diameter$
+}
+@ROL_MODEL[rotanks-*]:HAS[#_rotanksApplyDefaults,~lowerDiameter]:FOR[ROTanks]
+{
+	&lowerDiameter = #$diameter$
+}
+@ROL_MODEL[rotanks-*]:HAS[#_rotanksApplyDefaults,~diameter]:FOR[ROTanks]
+{
+	// diameter MUST be set for scaling to match the diameter slider
+	&diameter = #$lowerDiameter$
+}
+@ROL_MODEL[rotanks-*]:HAS[#_rotanksApplyDefaults]:FOR[ROTanks]
+{
+	&orientation = CENTRAL
+	&style = Normal-Tank
+	&mass = 0
+	&cost = 0
+	&minVerticalScale = 0.1
+	&maxVerticalScale = 10
+
+	// 5% less than procparts perfect cylinders. Should be vaguely reasonable
+	// for your average pill shape; probably too good for short tanks, too mean
+	// for long ones. Outlier models can override it however they want
+	// (or can just set volume directly)
+	&_defaultVolumeMultiplier = 0.95
+
+	_defaultVolume = #$upperDiameter$
+	@_defaultVolume += #$lowerDiameter$
+	@_defaultVolume /= 4  // upper+lower/2 = avgDiam, /2 = avg radius
+	@_defaultVolume *= #$_defaultVolume$
+	@_defaultVolume *= 3.1416
+	@_defaultVolume *= #$height$
+	@_defaultVolume *= #$_defaultVolumeMultiplier$
+	&volume = #$_defaultVolume$
+
+	!_defaultVolume = delete
+	!_defaultVolumeMultiplier = delete
+	!_rotanksApplyDefaults = delete
+}

--- a/GameData/ROTanks/Compatibility/misc/NFExploration-ModelData.cfg
+++ b/GameData/ROTanks/Compatibility/misc/NFExploration-ModelData.cfg
@@ -1,0 +1,202 @@
+// ROL_MODELs for ROTanks Cores using Near Future Exploration tank models
+// Initial version covers the inline nfex-fueltank-stack-*
+
+// the nfex-fueltank-stack-* models have 7 tank variants; the -mediums also have 3 structure variants!
+// magic below keeps it DRY
+ROL_MODEL:NEEDS[NearFutureExploration]
+{
+	name = rotanks-nfex-tank-multi-1-gold
+	title = Tiny Gold
+	modelName = NearFutureExploration/Parts/FuelTank/nfex-fueltank-stack-tiny-1
+	diameter = 0.6
+	height = 0.25
+	volume = 0.033
+	_rotanksApplyDefaults = true
+	_transformPrefix = ProbeTankMini
+	_goldSuffix = GoldFoil
+	_silverSuffix = SilverFoil
+	_xenonSuffix = Xenon
+	// there's a single structural transform, ProbeTankMini_Core.
+	// Could provide -bare and -structure variants.
+}
+
+ROL_MODEL:NEEDS[NearFutureExploration]
+{
+	name = rotanks-nfex-tank-multi-2-gold-bare
+	title = Large Gold A
+	modelName = NearFutureExploration/Parts/FuelTank/nfex-fueltank-stack-medium-1
+	diameter = 1.47
+	height = 1.45
+	volume = 1.05
+	_rotanksApplyDefaults = true
+	_transformPrefix = Tank1875_Large
+}
+
+ROL_MODEL:NEEDS[NearFutureExploration]
+{
+	name = rotanks-nfex-tank-multi-3-gold-bare
+	title = Medium Gold A
+	modelName = NearFutureExploration/Parts/FuelTank/nfex-fueltank-stack-medium-2
+	diameter = 1.47
+	height = 0.75
+	volume = 0.49
+	_rotanksApplyDefaults = true
+	_transformPrefix = Tank1875_Med
+}
+
+ROL_MODEL:NEEDS[NearFutureExploration]
+{
+	name = rotanks-nfex-tank-multi-4-gold-bare
+	title = Short Gold A
+	modelName = NearFutureExploration/Parts/FuelTank/nfex-fueltank-stack-medium-3
+	diameter = 1.47
+	height = 0.42
+	volume = 0.222
+	_rotanksApplyDefaults = true
+	_transformPrefix = Tank1875_Short
+}
+
+ROL_MODEL:NEEDS[NearFutureExploration]
+{
+	name = rotanks-nfex-tank-multi-5-gold
+	title = Large Gold
+	modelName = NearFutureExploration/Parts/FuelTank/nfex-fueltank-radial-small-1
+	diameter = 0.42
+	height = 1.45
+	volume = 0.138
+	positionOffset = -0.09, 0, 0
+	_rotanksApplyDefaults = true
+	_transformPrefix = Tank1875_RadialLarge
+}
+
+ROL_MODEL:NEEDS[NearFutureExploration]
+{
+	name = rotanks-nfex-tank-multi-6-gold
+	title = Medium Gold
+	modelName = NearFutureExploration/Parts/FuelTank/nfex-fueltank-radial-small-2
+	diameter = 0.42
+	height = 0.75
+	volume = 0.084
+	positionOffset = -0.09, 0, 0
+	_rotanksApplyDefaults = true
+	_transformPrefix = Tank1875_RadialMed
+}
+
+ROL_MODEL:NEEDS[NearFutureExploration]
+{
+	name = rotanks-nfex-tank-multi-7-gold
+	title = Small Gold
+	modelName = NearFutureExploration/Parts/FuelTank/nfex-fueltank-radial-small-3
+	diameter = 0.42
+	height = 0.43
+	volume = 0.041
+	positionOffset = -0.06, 0, 0
+	_rotanksApplyDefaults = true
+	_transformPrefix = Tank1875_RadialSmall
+}
+
+ROL_MODEL:NEEDS[NearFutureExploration]
+{
+	name = rotanks-nfex-tank-multi-8-gold
+	title = Tiny Gold
+	modelName = NearFutureExploration/Parts/FuelTank/nfex-fueltank-radial-tiny-1
+	diameter = 0.24
+	height = 0.24
+	volume = 0.007
+	rotationOffset = 0, 180, 0
+	positionOffset = -0.02, 0, 0
+	_rotanksApplyDefaults = true
+	_transformPrefix = ProbeTankRadial
+	_goldSuffix = GoldFoil
+	_silverSuffix = SilverFoil
+	_xenonSuffix = Xenon
+}
+
+
+@ROL_MODEL[rotanks-nfex-tank-*]:HAS[#_transformPrefix]
+{
+	&_goldSuffix = Foil
+	&_silverSuffix = FoilSilver
+	&_xenonSuffix = Xe
+	_goldTransform = #$_transformPrefix$_$_goldSuffix$
+	disableTransform = #$_transformPrefix$_$_silverSuffix$
+	disableTransform = #$_transformPrefix$_Metal
+	disableTransform = #$_transformPrefix$_RCS
+	disableTransform = #$_transformPrefix$_$_xenonSuffix$
+	disableTransform = #$_transformPrefix$_Ar
+	disableTransform = #$_transformPrefix$_Li
+	!_goldSuffix = delete
+	!_silverSuffix = delete
+	!_xenonSuffix = delete
+}
+@ROL_MODEL[rotanks-nfex-tank-*-bare]:HAS[#_transformPrefix]
+{
+	disableTransform = #$_transformPrefix$_Structure
+	disableTransform = #$_transformPrefix$_StructureStack
+	disableTransform = #$_transformPrefix$_StructureCompact
+}
+@ROL_MODEL[rotanks-nfex-tank-*]:HAS[#_transformPrefix]
+{
+	!_transformPrefix = delete
+}
+
++ROL_MODEL[rotanks-nfex-tank-multi-*-gold*]
+{
+	@name ^= :gold:silver:
+	@title ^= :Gold:Silver:
+	@disableTransform,0 = #$_goldTransform$
+}
++ROL_MODEL[rotanks-nfex-tank-multi-*-gold*]
+{
+	@name ^= :gold:metal:
+	@title ^= :Gold:Metal:
+	@disableTransform,1 = #$_goldTransform$
+}
++ROL_MODEL[rotanks-nfex-tank-multi-*-gold*]
+{
+	@name ^= :gold:rcs:
+	@title ^= :Gold:RCS:
+	@disableTransform,2 = #$_goldTransform$
+}
++ROL_MODEL[rotanks-nfex-tank-multi-*-gold*]
+{
+	@name ^= :gold:xe:
+	@title ^= :Gold:Xe:
+	@disableTransform,3 = #$_goldTransform$
+}
++ROL_MODEL[rotanks-nfex-tank-multi-*-gold*]
+{
+	@name ^= :gold:ar:
+	@title ^= :Gold:Ar:
+	@disableTransform,4 = #$_goldTransform$
+}
++ROL_MODEL[rotanks-nfex-tank-multi-*-gold*]
+{
+	@name ^= :gold:li:
+	@title ^= :Gold:Li:
+	@disableTransform,5 = #$_goldTransform$
+}
+
++ROL_MODEL[rotanks-nfex-tank-multi-*-bare]
+{
+	@name ^= :-bare:-struct:
+	@title ^= : A$: B:
+	!disableTransform,6 = delete
+}
++ROL_MODEL[rotanks-nfex-tank-multi-*-bare]
+{
+	@name ^= :-bare:-stack:
+	@title ^= : A$: C:
+	!disableTransform,7 = delete
+}
++ROL_MODEL[rotanks-nfex-tank-multi-*-bare]
+{
+	@name ^= :-bare:-compact:
+	@title ^= : A$: D:
+	!disableTransform,8 = delete
+}
+
+@ROL_MODEL[rotanks-nfex-tank-multi-*]:HAS[#_goldTransform]
+{
+	!_goldTransform = delete
+}

--- a/GameData/ROTanks/Compatibility/misc/ReStock-ModelData.cfg
+++ b/GameData/ROTanks/Compatibility/misc/ReStock-ModelData.cfg
@@ -1,0 +1,418 @@
+// ROL_MODELs for ROTanks Cores using ReStock and ReStock Plus models
+// Initial version covers the inline nfex-fueltank-stack-*
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-flt100
+	title = FL-T100
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-125-4
+	diameter = 1.25
+	height = 0.68
+	_rotanksApplyDefaults = true
+	// FIXME: the FLTx00 tanks each have 4 texture variants, need ti figure out how to use texturesets
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-flt200
+	title = FL-T200
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-125-3
+	diameter = 1.25
+	height = 1.15
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-flt400
+	title = FL-T400
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-125-2
+	diameter = 1.25
+	height = 1.95
+	verticalOffset = -0.03
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-flt800
+	title = FL-T800
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-125-1
+	diameter = 1.25
+	height = 3.75
+	_rotanksApplyDefaults = true
+}
+
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-oscar-a
+	title = Oscar-A
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-0625-5
+	diameter = 0.625
+	height = 0.2
+	_rotanksApplyDefaults = true
+	disableTransform = Tank0625_16_White
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-oscar-b
+	title = Oscar-B
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-0625-4
+	diameter = 0.625
+	height = 0.365
+	_rotanksApplyDefaults = true
+	disableTransform = Tank0625_8_White
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-oscar-c
+	title = Oscar-C
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-0625-3
+	diameter = 0.625
+	height = 0.725
+	_rotanksApplyDefaults = true
+	disableTransform = Tank0625_4_White
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-oscar-d
+	title = Oscar-D
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-0625-2
+	diameter = 0.625
+	height = 1.42
+	_rotanksApplyDefaults = true
+	disableTransform = Tank0625_2_White
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-oscar-e
+	title = Oscar-E
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-0625-1
+	diameter = 0.625
+	height = 2.81
+	_rotanksApplyDefaults = true
+	disableTransform = Tank0625_White
+}
+
+// All the restock oscars have 2 variants. FIXME: and use themes
++ROL_MODEL[rotanks-restock-tank-oscar-*]:HAS[#disableTransform[*_White]]
+{
+	@name ^= :$:-2:
+	@title ^= :$: 2:
+	@disableTransform ^= :_White::
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-siv-64k
+	title = SIV 64k
+	SUBMODEL {
+		modelName = ReStock/Assets/FuelTank/restock-fueltank-5-4
+		disableTransform = 5mMiniOrange
+	}
+	height = 1.86
+}
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-siv-128k
+	title = SIV 128k
+	SUBMODEL {
+		modelName = ReStock/Assets/FuelTank/restock-fueltank-5-3
+		disableTransform = 5mSmallOrange
+	}
+	height = 3.75
+}
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-siv-256k
+	title = SIV 256k
+	SUBMODEL {
+		modelName = ReStock/Assets/FuelTank/restock-fueltank-5-2
+		disableTransform = 5mMediumOrange
+	}
+	height = 7.5
+}
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-siv-512k
+	title = SIV 512k
+	SUBMODEL {
+		modelName = ReStock/Assets/FuelTank/restock-fueltank-5-1
+		disableTransform = 5mLongOrange
+	}
+	height = 15
+}
+@ROL_MODEL[rotanks-restock-tank-siv-*]
+{
+	diameter = 5
+	_rotanksApplyDefaults = true
+
+	&_offset = #$height$
+	@_offset /= 2
+	// TODO: consider using endcaps as actual NOSEs
+	SUBMODEL
+	{
+		modelName = ReStock/Assets/FuelTank/restock-endcap-5-1
+		position = #0, $../_offset$, 0
+	}
+	SUBMODEL
+	{
+		modelName = ReStock/Assets/FuelTank/restock-endcap-5-1
+		position = #0, -$../_offset$, 0
+		rotation = 180, 0, 0
+	}
+}
+@ROL_MODEL[rotanks-restock-tank-siv-*]
+{
+	!_offset = delete // don't delete in same node that ../references it, it gets deleted first
+}
+@ROL_MODEL[rotanks-restock-tank-siv-64k]
+{
+	// 64k is too short for a pill shape, so it gets ends that make it look like a fat torus.
+	// TODO: see how it looks on the short -375? its pill shape also looks iffy
+	@SUBMODEL:HAS[#position] {
+		@modelName ^= :-5-1$:-5-2:
+	}
+}
++ROL_MODEL[rotanks-restock-tank-siv-*]
+{
+	@name ^= :$:-2:
+	@title ^= :$: 2:
+	@SUBMODEL:HAS[#disableTransform]
+	{
+		@disableTransform ^= :Orange:BlackWhite:
+	}
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-375-1
+	title = S3-14400
+	SUBMODEL {
+		modelName = ReStock/Assets/FuelTank/restock-fueltank-375-1
+		disableTransform = TankLargeSOFI
+	}
+	height = 7.47
+}
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-375-2
+	title = S3-7200
+	SUBMODEL {
+		modelName = ReStock/Assets/FuelTank/restock-fueltank-375-2
+		disableTransform = TankMedSOFI
+	}
+	height = 3.86
+}
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-375-3
+	title = S3-3600
+	SUBMODEL {
+		modelName = ReStock/Assets/FuelTank/restock-fueltank-375-3
+		disableTransform = TankSmallSOFI
+	}
+	height = 1.92
+}
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-375-4
+	title = S3-1800
+	SUBMODEL {
+		modelName = ReStock/Assets/FuelTank/restock-fueltank-375-4
+		disableTransform = TankTinySOFI
+	}
+	height = 0.96
+}
+@ROL_MODEL[rotanks-restock-tank-375-*]
+{
+	diameter = 3.75
+	_rotanksApplyDefaults = true
+
+	_offset = #$height$
+	@_offset /= 2
+	SUBMODEL
+	{
+		modelName = ReStock/Assets/FuelTank/restock-endcap-fueltank-375-orange
+		position = #0, $../_offset$, 0
+	}
+	SUBMODEL
+	{
+		modelName = ReStock/Assets/FuelTank/restock-endcap-fueltank-375-orange
+		position = #0, -$../_offset$, 0
+		rotation = 180, 0, 0
+	}
+}
+@ROL_MODEL[rotanks-restock-tank-375*]
+{
+	!_offset = delete
+}
++ROL_MODEL[rotanks-restock-tank-375*]
+{
+	@name ^= :$:-2:
+	@title ^= :$: 2:
+	@SUBMODEL:HAS[#disableTransform] {
+		@disableTransform ^= :SOFI::
+	}
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-1875-1-1
+	title = FL-X1800
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-1875-1
+	disableTransform = Tank1875LongGrey
+	disableTransform = Tank1875LongOrange
+	height = 3.79
+}
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-1875-2-1
+	title = FL-X900
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-1875-2
+	disableTransform = Tank1875MedGrey
+	disableTransform = Tank1875MedOrange
+	height = 1.91
+}
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-1875-3-1
+	title = FL-X440
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-1875-3
+	disableTransform = Tank1875SmallGrey
+	disableTransform = Tank1875SmallOrange
+	height = 0.98
+}
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-1875-4-1
+	title = FL-X220
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-1875-4
+	disableTransform = Tank1875TinyGrey
+	disableTransform = Tank1875TinyOrange
+	height = 0.51
+}
+@ROL_MODEL[rotanks-restock-tank-1875-*]
+{
+	diameter = 1.875
+	_rotanksApplyDefaults = true
+}
++ROL_MODEL[rotanks-restock-tank-1875-*-1]
+{
+	@name ^= :-1$:-2:
+	@title ^= :$: 2:
+	@disableTransform,* ^= :Grey$::
+}
++ROL_MODEL[rotanks-restock-tank-1875-*-1]
+{
+	@name ^= :-1$:-3:
+	@title ^= :$: 3:
+	@disableTransform,* ^= :Orange::
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-radial-round
+	title = Round
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-foil-sphere-1
+	height = 0.625
+	diameter = 0.625
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-radial-capsule
+	title = Pill
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-foil-capsule-1
+	height = 1.25
+	diameter = 0.625
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-rcs-radial-1
+	title = RCS
+	modelName = ReStock/Assets/FuelTank/restock-fuel-tank-rcs-radial-tiny-1
+	height = 0.34
+	diameter = 0.34
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-rcs-radial-2
+	title = RCS 2
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-rcs-radial-1
+	height = 0.56
+	diameter = 0.56
+	rotationOffset = 0, 90, 0
+	positionOffset = -0.2, 0, 0
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-rcs-radial-3
+	title = RCS 3
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-rcs-radial-2
+	height = 1.47
+	diameter = 0.56
+	rotationOffset = 0, 90, 0
+	positionOffset = 0.35, 0, 0
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-xenon-radial
+	title = Xenon
+	modelName = ReStock/Assets/FuelTank/restock-fueltank-xenon-radial-1
+	height = 0.6
+	diameter = 0.3
+	rotationOffset = 0, 90, 0
+	positionOffset = 0.25, 0, 0
+}
+
+ROL_MODEL:NEEDS[ReStock]
+{
+	name = rotanks-restock-tank-goo-radial
+	title = Goo
+	modelName = ReStock/Assets/Science/restock-goocanister-radial-1
+	height = 1.1
+	diameter = 0.355
+	rotationOffset = 0, 90, 0
+	positionOffset = 0.25, 0, 0
+	disableTransform = Mount_Compact
+}
+
++ROL_MODEL[rotanks-restock-tank-goo-radial]
+{
+	@name = rotanks-restock-tank-goo-radial-compact
+	@title = Goo (bare)
+	@disableTransform = Mount_Truss
+}
+
+
+ROL_MODEL:NEEDS[ReStockPlus]
+{
+	name = rotanks-restockplus-tank-probe-1
+	title = Probe 1
+	modelName = ReStockPlus/Assets/FuelTank/restock-fuel-tank-probe-1
+	diameter = 0.450
+	height = 0.365
+	volume = 0.026
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[ReStockPlus]
+{
+	name = rotanks-restockplus-tank-probe-2
+	title = Probe 2
+	modelName = ReStockPlus/Assets/FuelTank/restock-fuel-tank-probe-2
+	diameter = 0.450
+	height = 0.180
+	volume = 0.01
+	_rotanksApplyDefaults = true
+}

--- a/GameData/ROTanks/Compatibility/misc/Squad-ModelData.cfg
+++ b/GameData/ROTanks/Compatibility/misc/Squad-ModelData.cfg
@@ -1,0 +1,529 @@
+// ROL_MODELs for ROTanks Cores using stock Squad models
+// Initial version covers 1.25m, 2.5m, 3.75m, Mk2 and Mk3 tanks and adapters
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-flt100
+	title = FL-T100
+	modelName = Squad/Parts/FuelTank/Size1_Tanks/Size1Tank_01
+	diameter = 1.25
+	height = 0.68
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-flt200
+	title = FL-T200
+	modelName = Squad/Parts/FuelTank/Size1_Tanks/Size1Tank_02
+	diameter = 1.25
+	height = 1.15
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-flt400
+	title = FL-T400
+	modelName = Squad/Parts/FuelTank/Size1_Tanks/Size1Tank_03
+	diameter = 1.25
+	height = 1.95
+	verticalOffset = -0.03
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-flt800
+	title = FL-T800
+	modelName = Squad/Parts/FuelTank/Size1_Tanks/Size1Tank_04
+	diameter = 1.25
+	height = 3.77
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-size1-size2
+	title = Adapter 1
+	modelName = Squad/Parts/FuelTank/adapterTanks/Size2-Size1
+	upperDiameter = 1.25
+	lowerDiameter = 2.5
+	height = 2.56
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-size1-size2-slant
+	title = Adapter 2
+	modelName = Squad/Parts/FuelTank/adapterTanks/Size2-Size1Slant
+	upperDiameter = 1.25
+	lowerDiameter = 2.5
+	height = 2.56
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-rocko-1
+	title = Rockomax 8
+	modelName = Squad/Parts/FuelTank/RockomaxTanks/Assets/Rockomax8
+	diameter = 2.5
+	height = 0.98
+	disableTransform = Rockomax_8_Orange
+	_rotanksApplyDefaults = true
+}
+
++ROL_MODEL[rotanks-squad-tank-rocko-1]
+{
+	@name = rotanks-squad-tank-rocko-1b
+	@title = Rockomax 8b
+	@disableTransform = Rockomax_8_White
+	// FIXME: Rockomax8BW's Orange variant uses themeName=Orange; no equivalent
+	//  in ROTanks? It also specifies an alternate tecture, couldn't get it to
+	//  work with KSP_TEXTURE_SETS. So this is just a slightly different b&w option
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-rocko-2
+	title = Rockomax 16
+	modelName = Squad/Parts/FuelTank/RockomaxTanks/Assets/Rockomax16
+	diameter = 2.5
+	height = 1.92
+	_rotanksApplyDefaults = true
+	// FIXME: Rockomax18_BW also has an Orange variant, but without an alternate
+	//  transform, so nothing different to offer here.
+	//  There's also an ESA variant in the same boat.
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-rocko-3
+	title = Rockomax 32
+	modelName = Squad/Parts/FuelTank/RockomaxTanks/Assets/Rockomax32
+	diameter = 2.5
+	height = 3.8
+	disableTransform = Rockomax_32_Orange
+	disableTransform = Rockomax_32_ESA
+	_rotanksApplyDefaults = true
+}
+
++ROL_MODEL[rotanks-squad-tank-rocko-3]
+{
+	@name = rotanks-squad-tank-rocko-3b
+	@title = Rockomax 32b
+	@disableTransform,0 = Rockomax_32_White
+	// this one... works fine despite not touching theme and texture?
+}
+
++ROL_MODEL[rotanks-squad-tank-rocko-3]
+{
+	@name = rotanks-squad-tank-rocko-3c
+	@title = Rockomax 32c
+	@disableTransform,1 = Rockomax_32_White
+	// this one too?
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-rocko-4
+	title = Rockomax 64
+	modelName = Squad/Parts/FuelTank/RockomaxTanks/Assets/Rockomax64
+	diameter = 2.5
+	height = 7.53
+	disableTransform = Rockomax_64_Orange
+	_rotanksApplyDefaults = true
+}
+
++ROL_MODEL[rotanks-squad-tank-rocko-4]
+{
+	@name = rotanks-squad-tank-rocko-4b
+	@title = Rockomax 64 b
+	@disableTransform = Rockomax_64_White
+	// FIXME: like Rockomax 8, Orange theme/texture MIA
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-kerbo-1
+	title = Kerbodyne 1
+	modelName = Squad/Parts/FuelTank/Size3Tanks/Size3SmallTank
+	diameter = 3.75
+	height = 1.95
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-kerbo-2
+	title = Kerbodyne 2
+	modelName = Squad/Parts/FuelTank/Size3Tanks/Size3MediumTank
+	diameter = 3.75
+	height = 3.87
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-kerbo-3
+	title = Kerbodyne 3
+	modelName = Squad/Parts/FuelTank/Size3Tanks/Size3LargeTank
+	diameter = 3.75
+	height = 7.7
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-rcs-1
+	title = FL-R20
+	modelName = Squad/Parts/FuelTank/RCSFuelTankR10/model
+	diameter = 0.625
+	height = 0.382
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-rcs-2
+	title = FL-R120
+	modelName = Squad/Parts/FuelTank/RCSFuelTankR25/RCSFuelTankR25
+	diameter = 1.25
+	height = 0.585
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-rcs-3
+	title = FL-R750
+	modelName = Squad/Parts/FuelTank/RCSFuelTankR1/RCSFuelTankR1_01
+	diameter = 2.5
+	height = 1.075
+	_rotanksApplyDefaults = true
+	// FIXME: part has 2 variants, using themes and alternate textures
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-rcs-radial
+	title = RCS
+	modelName = Squad/Parts/FuelTank/RCSTankRadial/model
+	diameter = 0.55
+	height = 0.6
+	rotationOffset = 0, 90, 0
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-oscar-b
+	title = Oscar-B
+	modelName = Squad/Parts/FuelTank/fuelTankOscarB/model
+	diameter = 0.625
+	height = 0.36
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk2-short-1
+	title = Short 1
+	modelName = Squad/Parts/FuelTank/mk2FuselageShort/FuselageShortLFO
+	diameter = 1.5 // with "wings" extending to 2.5
+	height = 1.875
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk2-short-2
+	title = Short 2
+	modelName = Squad/Parts/FuelTank/mk2FuselageShort/FuselageShortLiquid
+	diameter = 1.5
+	height = 1.875
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk2-short-3
+	title = Short 3
+	modelName = Squad/Parts/FuelTank/mk2FuselageShort/FuselageShortMono
+	diameter = 1.5
+	height = 1.875
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk2-long-1
+	title = Long 1
+	modelName = Squad/Parts/FuelTank/mk2FuselageLong/FuselageLongLFO
+	diameter = 1.5
+	height = 3.75
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk2-long-2
+	title = Long 2
+	modelName = Squad/Parts/FuelTank/mk2FuselageLong/FuselageLongLiquid
+	diameter = 1.5
+	height = 3.75
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk2-adapter-1
+	title = Adapter 1
+	modelName = Squad/Parts/FuelTank/mk2Adapters/standard
+	upperDiameter = 1.25
+	lowerDiameter = 1.5
+	height = 1.9
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk2-adapter-2
+	title = Adapter 2
+	modelName = Squad/Parts/FuelTank/mk2Adapters/long
+	upperDiameter = 1.25
+	lowerDiameter = 1.5
+	height = 3.78
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk2-adapter-3
+	title = Adapter 3
+	modelName = Squad/Parts/FuelTank/adapterTanks/Size2-Mk2
+	upperDiameter = 1.5
+	lowerDiameter = 2.5
+	height = 3.78
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk2-adapter-4
+	title = Adapter 4
+	// bottom node will be silly, but surface attachment exists
+	modelName = Squad/Parts/FuelTank/mk2Adapters/bicoupler
+	diameter = 1.5
+	height = 1.9
+	_rotanksApplyDefaults = true
+}
+
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk3-mono
+	title = Mono
+	modelName = Squad/Parts/FuelTank/mk3Fuselage/MONO
+	diameter = 3.25 // 3.7 cylinder with sides trimmed. should maybe pretend it's a 3.4m oval
+	height = 1.25
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk3-short-1
+	title = Short 1
+	modelName = Squad/Parts/FuelTank/mk3Fuselage/LFO_25
+	diameter = 3.25
+	height = 2.5
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk3-short-2
+	title = Short 2
+	modelName = Squad/Parts/FuelTank/mk3Fuselage/LF_25
+	diameter = 3.25
+	height = 2.5
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk3-medium-1
+	title = Medium 1
+	modelName = Squad/Parts/FuelTank/mk3Fuselage/LFO_50
+	diameter = 3.25
+	height = 5
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk3-medium-2
+	title = Medium 2
+	modelName = Squad/Parts/FuelTank/mk3Fuselage/LF_50
+	diameter = 3.25
+	height = 5
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk3-long-1
+	title = Long 1
+	modelName = Squad/Parts/FuelTank/mk3Fuselage/LFO_100
+	diameter = 3.25
+	height = 10
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk3-long-2
+	title = Long 2
+	modelName = Squad/Parts/FuelTank/mk3Fuselage/LF_100
+	diameter = 3.25
+	height = 10
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk3-adapter-mk2
+	title = Adapter 1
+	modelName = Squad/Parts/FuelTank/adapterTanks/Mk3-Mk2
+	upperDiameter = 1.5
+	lowerDiameter = 3.25
+	height = 5
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk3-adapter-size2
+	title = Adapter 2
+	modelName = Squad/Parts/FuelTank/adapterTanks/Mk3-Size2
+	upperDiameter = 2.5
+	lowerDiameter = 3.25
+	height = 3.78
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk3-adapter-size2-slant
+	title = Adapter 3
+	modelName = Squad/Parts/FuelTank/adapterTanks/Mk3-Size2Slant
+	upperDiameter = 2.5
+	lowerDiameter = 3.25
+	height = 3.78
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-mk3-adapter-size3
+	title = Adapter 4
+	modelName = Squad/Parts/FuelTank/adapterTanks/Size3-Mk3
+	upperDiameter = 3.25
+	lowerDiameter = 3.75
+	height = 1.9
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	// this could be a Mount
+	name = rotanks-squad-tank-mk3-adapter-shuttle
+	title = Adapter 5
+	modelName = Squad/Parts/FuelTank/adapterTanks/ShuttleAdapter
+	diameter = 3.25
+	height = 1
+	// TODO: probably wants an offset
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-xenon-small
+	title = Xenon 1
+	modelName = Squad/Parts/FuelTank/xenonTank/model
+	diameter = 0.625
+	height = 0.285
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-xenon-large
+	title = Xenon 2
+	modelName = Squad/Parts/FuelTank/xenonTankLarge/model
+	diameter = 1.25
+	height = 0.625
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-xenon-radial
+	title = Xenon
+	modelName = Squad/Parts/FuelTank/xenonTankRadial/model
+	diameter = 0.3
+	height = 0.55
+	volume = 0.35
+	rotationOffset = 0, 90, 0
+	positionOffset = 0.20, 0, 0
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-radial-round
+	title = Round
+	modelName = Squad/Parts/FuelTank/FoilTanks/RadialTank_Round
+	diameter = 0.625
+	height = 0.128
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-radial-capsule
+	title = Pill
+	modelName = Squad/Parts/FuelTank/FoilTanks/RadialTank_Capsule
+	diameter = 0.625
+	height = 1.25
+	volume = 0.320
+	_rotanksApplyDefaults = true
+}
+
+// would make a nice radial tank, but can't find a way to prevent the
+// Open animation from autoplaying
+//ROL_MODEL:NEEDS[Squad]
+//{
+//	name = rotanks-squad-tank-radial-goo
+//	title = Goo
+//	modelName = Squad/Parts/Science/GooExperiment/GooExperiment
+//	diameter = 0.4
+//	height = 1.18
+//	rotationOffset = 0, 90, 0
+//	positionOffset = -0.1, 0, 0
+//	_rotanksApplyDefaults = true
+//}
+
+ROL_MODEL:NEEDS[Squad]
+{
+	name = rotanks-squad-tank-radial-ore
+	title = Ore
+	modelName = Squad/Parts/Resources/RadialTank/RadialOreTank
+	diameter = 0.5
+	height = 1.2
+	rotationOffset = 0, -90, 0
+	positionOffset = 0.25, 0, 0
+	_rotanksApplyDefaults = true
+}

--- a/GameData/ROTanks/Compatibility/misc/Vens-ModelData.cfg
+++ b/GameData/ROTanks/Compatibility/misc/Vens-ModelData.cfg
@@ -1,0 +1,107 @@
+// ROL_MODELs for ROTanks Cores using stock Squad models
+// Initial version covers an arbitrary set of models from Ven's New Parts
+
+ROL_MODEL:NEEDS[VenStockRevamp/PartBin]
+{
+	name = rotanks-vens-tank-octo
+	title = OctoTank
+	modelName = VenStockRevamp/PartBin/NewParts/Structural/OctoTank
+	diameter = 0.625
+	height = 0.275
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[VenStockRevamp/PartBin]
+{
+	name = rotanks-vens-tank-oscar-a
+	title = Oscar-A
+	modelName = VenStockRevamp/PartBin/NewParts/Propulsion/fuelTankOscarA
+	diameter = 0.625
+	height = 0.185
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[VenStockRevamp/PartBin]
+{
+	name = rotanks-vens-tank-oscar-c
+	// the file name says D, but the actual texture says C
+	title = Oscar-C
+	modelName = VenStockRevamp/PartBin/NewParts/Propulsion/fuelTankOscarD
+	diameter = 0.625
+	height = 1.05
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[VenStockRevamp/PartBin]
+{
+	name = rotanks-vens-tank-oscar-d
+	title = Oscar-D
+	modelName = VenStockRevamp/PartBin/NewParts/Propulsion/fuelTankOscarE
+	diameter = 0.625
+	height = 2.04
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[VenStockRevamp/PartBin]
+{
+	name = rotanks-vens-tank-soft-1
+	title = Soft Shell 1
+	modelName = VenStockRevamp/PartBin/NewParts/SoftTanks/MK1
+	diameter = 1.25
+	height = 2.4
+	volume = 2.4 // these are undeniably pill shapes, so don't use cylinder calcs
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[VenStockRevamp/PartBin]
+{
+	name = rotanks-vens-tank-soft-2
+	title = Soft Shell 2
+	modelName = VenStockRevamp/PartBin/NewParts/SoftTanks/MK2
+	diameter = 1.25
+	height = 4.5
+	volume = 5
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[VenStockRevamp/PartBin]
+{
+	name = rotanks-vens-tank-soft-3
+	title = Soft Shell 3
+	modelName = VenStockRevamp/PartBin/NewParts/SoftTanks/MK3
+	diameter = 2.5
+	height = 2.45
+	volume = 8
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[VenStockRevamp/PartBin]
+{
+	name = rotanks-vens-tank-soft-4
+	title = Soft Shell 4
+	modelName = VenStockRevamp/PartBin/NewParts/SoftTanks/MK4
+	diameter = 2.5
+	height = 5.25
+	volume = 21
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[VenStockRevamp/PartBin]
+{
+	name = rotanks-vens-tank-soft-5
+	title = Soft Shell 5
+	modelName = VenStockRevamp/PartBin/NewParts/SoftTanks/MK5
+	diameter = 2.5
+	height = 40
+	_rotanksApplyDefaults = true
+}
+
+ROL_MODEL:NEEDS[VenStockRevamp/PartBin]
+{
+	name = rotanks-vens-tank-rockomax-48
+	title = Rockomax 48
+	modelName = VenStockRevamp/PartBin/NewParts/Propulsion/X200-48
+	diameter = 2.5
+	height = 5.55
+	_rotanksApplyDefaults = true
+}

--- a/GameData/ROTanks/Compatibility/reDIRECT-Tank.cfg
+++ b/GameData/ROTanks/Compatibility/reDIRECT-Tank.cfg
@@ -1,133 +1,16 @@
-//	===========================================================================
-//	All work here was originally from Shadowmage and SSTU. I have adapted their
-//	work to be more usable for our purposes in Realism Overhaul, but all credit
-//	should be given to Shadowmage for the great work!
-//	===========================================================================
-
 PART:NEEDS[reDIRECT]
 {
-	module = Part
 	name = ROT-reDIRECTTank
-	author = Shadowmage, Pap
-
-	//  ============================================================================
-	//  Model and Dimensions
-	//  ============================================================================
-
-	MODEL
-	{
-		model = ROLib/Assets/EmptyProxyModel
-	}
-
-	scale = 1.0
-	rescaleFactor = 1.0
-
-	node_stack_top 				= 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 2
-	node_stack_bottom 			= 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 2
-	node_stack_noseinterstage 	= 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 2
-	node_stack_mountinterstage	= 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 2
-	node_attach					= 2.5, 0.0, 0.0, 1.0, 0.0, 0.0, 0
-
-	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
-	attachRules = 1,1,1,1,0
-
-	//  ============================================================================
-	//  Title, Description, Category, Techs
-	//  ============================================================================
-
 	title = reDIRECT Modular Tank
-	manufacturer = Generic
-	description = This modular tank allows for many customizations. You can integrate top and bottom adapters, adjust the length and the diameter as well. It is comprised of many different tank types. You can choose the tank type below. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. The HP versions of the tanks are Highly Pressurized and are used for engines that require it.
-
-	tags = fuel, tank, modular, proc, procedural, redirect
-
-	mass = 1.0
-
-	category = FuelTank
-
-	TechRequired = unlockParts
-	cost = 150
-	entryCost = 1
-
-	//  ============================================================================
-	//	DO NOT CHANGE (Normally)
-	//  ============================================================================
-
-	maxTemp = 773.15
-	skinMaxTemp = 873.15
-	crashTolerance = 10
-	breakingForce = 250
-	breakingTorque = 250
-	fuelCrossFeed = true
-	subcategory = 0
-	emissiveConstant = 0.85
-	thermalMassModifier = 1.0
-	skinMassPerArea = 2.0
-	buoyancy = 0.95
-
-	//  ============================================================================
-	//  Modules and Resources
-	//  ============================================================================
-
-	MODULE
+	rotanksApplyDefaults = true
+}
+@PART[ROT-reDIRECTTank]:AFTER[a_ROTanks]
+{
+	@tags = #$tags$, redirect
+	@MODULE[ModuleROTank]
 	{
-		name = ModuleFuelTanks
-		volume = 556
-		utilizationTweakable = true
-		type = Default
-		typeAvailable = Default
-		typeAvailable = Structural
-		typeAvailable = Fuselage
-	}
-
-	MODULE
-	{
-		name = ModuleROTank
-
-		// Dimension Settings
-		diameterLargeStep = 1.0
-		diameterSmallStep = 0.1
-		diameterSlideStep = 0.001
-		minDiameter = 0.1
-		maxDiameter = 50.0
-		minLength = 0.1
-		maxLength = 50.0
-
-		// Adapter Settings
-		useAdapterMass = false
-		useAdapterCost = false
-
-		// Attach Node Settings
-		topNodeName = top
-		bottomNodeName = bottom
-		noseNodeNames = none
-		coreNodeNames = none
-		mountNodeNames = none
-		topInterstageNodeName = noseinterstage
-		bottomInterstageNodeName = mountinterstage
-
-		// Fairing Settings
-		topFairingIndex = -1
-		bottomFairingIndex = -1
-		centralFairingIndex = -1
-
-		// Default Values
-		currentDiameter = 5.0
-		currentLength = 5.0
-		currentVariant = SLS
-		currentNose = Model-None
-		currentCore = reSTOCK-SLS-Tank
-		currentMount = Model-None
-		currentNoseTexture = default
-		currentCoreTexture = default
-		currentMountTexture = default
-
-		// Model Handling
-		lengthWidth = false
-		validateNose = true
-		validateMount = true
-		hasNoseToRotate = true
-		hasMountToRotate = true
+		@currentVariant = SLS
+		@currentCore = reSTOCK-SLS-Tank
 
 		CORE
 		{
@@ -147,11 +30,8 @@ PART:NEEDS[reDIRECT]
 			model = reSTOCK-Shuttle-Tank
 		}
 
-		NOSE
+		@NOSE
 		{
-			// Generic
-			model = Model-None
-			
 			// reDIRECT Nose
 			model = reSTOCK-Jupiter-Tank
 			model = reSTOCK-Jupiter-Adapter
@@ -161,234 +41,16 @@ PART:NEEDS[reDIRECT]
 			model = reSTOCK-Ares-Adapter
 			model = reSTOCK-Ares-Adapter-2
 			model = reSTOCK-Shuttle-Nose
-
-			// Nosecones
-			model = Nosecone-1
-			model = Nosecone-2
-			model = Nosecone-3
-			model = Nosecone-4
-			model = Nosecone-5
-			model = Nosecone-6
-			model = Nosecone-7
-			model = Nosecone-8
-			model = Nosecone-9
-			model = Nosecone-10
-			model = Nosecone-11
-			model = Nosecone-12
-			model = Nosecone-13
-
-			// Domes
-			model = Adapter-Dome-A
-			model = Adapter-Dome-B
-			model = Adapter-Dome-Flat
-			model = Adapter-Dome-Half
-			model = Adapter-Dome-Half-Framed-S
-			model = Adapter-Dome-Half-Framed-M
-
-			// Adapters
-			model = Adapter-2-1-Flat
-			model = Adapter-2-1-Short
-			model = Adapter-2-1-Long
-			model = Adapter-3-1-Flat
-			model = Adapter-3-1-Short
-			model = Adapter-3-1-Long
-			model = Adapter-3-1-Extended
-			model = Adapter-3-2-Flat
-			model = Adapter-3-2-Short
-			model = Adapter-3-2-Long
-			model = Adapter-3-2-Extended
-			model = Adapter-4-1-Flat
-			model = Adapter-4-1-Short
-			model = Adapter-4-3-Flat
-			model = Adapter-4-3-Short
-			model = Adapter-4-3-Long
-
-			// Inverted Adapters
-			model = Adapter-1-2-Flat
-			model = Adapter-1-2-Short
-			model = Adapter-1-2-Long
-			model = Adapter-1-3-Flat
-			model = Adapter-1-3-Short
-			model = Adapter-1-3-Long
-			model = Adapter-2-3-Flat
-			model = Adapter-2-3-Short
-			model = Adapter-2-3-Long
-			model = Adapter-3-4-Flat
-			model = Adapter-3-4-Short
-			model = Adapter-3-4-Long
-
-			// Soyuz
-			model = Adapter-Soyuz
-			model = Adapter-R7
-			model = Adapter-Soyuz-S
-			model = Adapter-Soyuz-M
-			model = Adapter-Soyuz-L
-			model = Adapter-Soyuz-XL
-
-			// Split
-			model = Intertank-Split
-			model = Intertank-Sphere
 		}
 
-		MOUNT
+		@MOUNT
 		{
-			// Generic
-			model = Model-None
-			
 			// reDIRECT Mount
 			model = reSTOCK-Jupiter-Mount
 			model = reSTOCK-Jupiter-US-Mount
 			model = reSTOCK-SLS-Mount
 			model = reSTOCK-Ares-US-Mount
 			model = reSTOCK-Shuttle-End-Cap
-			
-			// reDIRECT Nose
-			model = reSTOCK-Jupiter-Tank
-			model = reSTOCK-Jupiter-Adapter
-			model = reSTOCK-Jupiter-US-Tank
-			model = reSTOCK-SLS-Tank-Short
-			model = reSTOCK-Ares-US-Tank
-			model = reSTOCK-Ares-Adapter
-			model = reSTOCK-Ares-Adapter-2
-			model = reSTOCK-Shuttle-Nose
-
-			// Engine Mounts
-			model = Mount-S-IC
-			model = Mount-S-IC-45
-			model = Mount-S-II
-			model = Mount-S-IVB
-			model = Mount-Generic
-			model = Mount-Boattail
-			model = Mount-Shroud-Tight
-			model = Mount-Shroud-S
-			model = Mount-Shroud-M
-			model = Mount-Shroud-L
-			model = Mount-Shroud-XL
-			model = Mount-SLS
-			model = Mount-SLS-6
-			model = Mount-Pyrios
-			model = Mount-Nova
-			model = Mount-Direct
-			model = Mount-Delta-IV
-			model = Mount-RD-107
-			model = Mount-RD-108
-			model = Mount-RD-108-45
-			model = Mount-Skeletal-S
-			model = Mount-Skeletal-M
-			model = Mount-Skeletal-L
-			
-			// BDB Mounts
-			model = Mount-BDB-LDC-Single
-			model = Mount-BDB-LDC-Dual
-			model = Mount-BDB-LDC-Quad
-			model = Mount-BDB-LDC-x7
-			model = Mount-BDB-LDC-25Adapter
-			model = Mount-BDB-LDC-375Adapter
-			model = Mount-BDB-CentaurD
-			model = Mount-BDB-CentaurV
-			model = Mount-BDB-Saturn-SII
-			model = Mount-BDB-Saturn-SII-7X
-			
-			// Hephaistos
-			model = Mount-Hephaistos-Vulcan
-
-			// Domes
-			model = Atlas-Mount
-			model = Adapter-Dome-A
-			model = Adapter-Dome-B
-			model = Adapter-Dome-Flat
-			model = Adapter-Dome-Half
-			model = Adapter-Dome-Half-Framed-S
-			model = Adapter-Dome-Half-Framed-M
-
-			// Adapters
-			model = Adapter-2-1-Flat
-			model = Adapter-2-1-Short
-			model = Adapter-2-1-Long
-			model = Adapter-3-1-Flat
-			model = Adapter-3-1-Short
-			model = Adapter-3-1-Long
-			model = Adapter-3-1-Extended
-			model = Adapter-3-2-Flat
-			model = Adapter-3-2-Short
-			model = Adapter-3-2-Long
-			model = Adapter-3-2-Extended
-			model = Adapter-4-1-Flat
-			model = Adapter-4-1-Short
-			model = Adapter-4-3-Flat
-			model = Adapter-4-3-Short
-			model = Adapter-4-3-Long
-
-			// Inverted Adapters
-			model = Adapter-1-2-Flat
-			model = Adapter-1-2-Short
-			model = Adapter-1-2-Long
-			model = Adapter-1-3-Flat
-			model = Adapter-1-3-Short
-			model = Adapter-1-3-Long
-			model = Adapter-2-3-Flat
-			model = Adapter-2-3-Short
-			model = Adapter-2-3-Long
-			model = Adapter-3-4-Flat
-			model = Adapter-3-4-Short
-			model = Adapter-3-4-Long
-
-			// Soyuz
-			model = Adapter-Soyuz-S-BOT
-			model = Adapter-Soyuz-M-BOT
-			model = Adapter-Soyuz-L-BOT
-			model = Adapter-Soyuz-XL-BOT
-
-			// Split
-			model = Intertank-Split
-			model = Intertank-Sphere
-
-			// Nosecones
-			model = Nosecone-1
-			model = Nosecone-2
-			model = Nosecone-3
-			model = Nosecone-4
-			model = Nosecone-5
-			model = Nosecone-6
-			model = Nosecone-7
-			model = Nosecone-8
-			model = Nosecone-9
-			model = Nosecone-10
-			model = Nosecone-11
-			model = Nosecone-12
-			model = Nosecone-13
 		}
-	}
-
-	MODULE
-	{
-		name = ROLSelectableNodes
-		nodeName = noseinterstage
-		startsEnabled = false
-	}
-
-	MODULE
-	{
-		name = ROLSelectableNodes
-		nodeName = mountinterstage
-		startsEnabled = false
-	}
-
-	MODULE
-	{
-		name = ModuleToggleCrossfeed
-		toggleFlight = true
-		toggleEditor = true
-		crossfeedStatus = true
-	}
-
-	MODULE
-	{
-		name = SSTURecolorGUI
-	}
-
-	MODULE
-	{
-		name = ROLCollisionHandler
 	}
 }

--- a/GameData/ROTanks/Parts/rotanks-defaults.cfg
+++ b/GameData/ROTanks/Parts/rotanks-defaults.cfg
@@ -1,0 +1,362 @@
+// Fills in common bits shared by many ROTanks tanks.
+//
+// Usage:
+// PART:NEEDS[something] {
+//  name = blah
+//  title = blah
+//  rotanksApplyDefaults = true
+// }
+// @PART[blah]:AFTER[a_ROTanks]
+// {
+//    @MODULE[ModuleROTanks] {
+//      @currentVariant = ...
+//      @currentCore = ...
+//      CORE {...}
+//      @NOSE {any overrides}
+//      @MOUNT {any overrides}
+// }}
+
+
+@PART:HAS[#rotanksApplyDefaults]:FOR[a_ROTanks] // MUST run BEFORE BEFORE[RealismOverhaul]!
+{
+	module = Part
+	author = Shadowmage, Pap, etc
+
+	//  ============================================================================
+	//  Model and Dimensions
+	//  ============================================================================
+
+	MODEL
+	{
+		model = ROLib/Assets/EmptyProxyModel
+	}
+
+	scale = 1.0
+	rescaleFactor = 1.0
+
+	node_stack_top 				= 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_bottom 			= 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 2
+	node_stack_noseinterstage 	= 0.0, 0.5, 0.0, 0.0, 1.0, 0.0, 2
+	node_stack_mountinterstage	= 0.0, -0.5, 0.0, 0.0, -1.0, 0.0, 2
+	node_attach					= 2.5, 0.0, 0.0, 1.0, 0.0, 0.0, 0
+
+	// stack, srfAttach, allowStack, allowSrfAttach, allowCollision
+	attachRules = 1,1,1,1,0
+
+	//  ============================================================================
+	//  Title, Description, Category, Techs
+	//  ============================================================================
+
+	manufacturer = Generic
+	description = This modular tank allows for many customizations. You can integrate top and bottom adapters, adjust the length and the diameter as well. It is comprised of many different tank types. You can choose the tank type below. Each tank type has a different base mass, different cost, and different amounts of utilization it can have. The HP versions of the tanks are Highly Pressurized and are used for engines that require it.
+
+	tags = fuel, tank, modular, proc, procedural
+
+	mass = 1.0
+
+	category = FuelTank
+
+	TechRequired = unlockParts
+	cost = 150
+	entryCost = 1
+
+	//  ============================================================================
+	//	DO NOT CHANGE (Normally)
+	//  ============================================================================
+
+	maxTemp = 773.15
+	skinMaxTemp = 873.15
+	crashTolerance = 10
+	breakingForce = 250
+	breakingTorque = 250
+	fuelCrossFeed = true
+	subcategory = 0
+	emissiveConstant = 0.85
+	thermalMassModifier = 1.0
+	skinMassPerArea = 2.0
+	buoyancy = 0.95
+
+	//  ============================================================================
+	//  Modules and Resources
+	//  ============================================================================
+
+	MODULE
+	{
+		name = ModuleFuelTanks
+		volume = 556
+		utilizationTweakable = true
+		type = Default
+		typeAvailable = Default
+		typeAvailable = Structural
+		typeAvailable = Fuselage
+	}
+
+	MODULE
+	{
+		name = ModuleROTank
+
+		// Dimension Settings
+		diameterLargeStep = 1.0
+		diameterSmallStep = 0.1
+		diameterSlideStep = 0.001
+		minDiameter = 0.1
+		maxDiameter = 50.0
+		minLength = 0.1
+		maxLength = 50.0
+
+		// Adapter Settings
+		useAdapterMass = false
+		useAdapterCost = false
+
+		// Attach Node Settings
+		topNodeName = top
+		bottomNodeName = bottom
+		noseNodeNames = none
+		coreNodeNames = none
+		mountNodeNames = none
+		topInterstageNodeName = noseinterstage
+		bottomInterstageNodeName = mountinterstage
+
+		// Fairing Settings
+		topFairingIndex = -1
+		bottomFairingIndex = -1
+		centralFairingIndex = -1
+
+		// Default Values
+		currentDiameter = 5.0
+		currentLength = 5.0
+		currentVariant = TBD
+		currentNose = Model-None
+		currentCore = TBD
+		currentMount = Model-None
+		currentNoseTexture = default
+		currentCoreTexture = default
+		currentMountTexture = default
+
+		// Model Handling
+		lengthWidth = false
+		validateNose = true
+		validateMount = true
+		hasNoseToRotate = true
+		hasMountToRotate = true
+
+		NOSE
+		{
+			// Generic
+			model = Model-None
+			
+			// Nosecones
+			model = Nosecone-1
+			model = Nosecone-2
+			model = Nosecone-3
+			model = Nosecone-4
+			model = Nosecone-5
+			model = Nosecone-6
+			model = Nosecone-7
+			model = Nosecone-8
+			model = Nosecone-9
+			model = Nosecone-10
+			model = Nosecone-11
+			model = Nosecone-12
+			model = Nosecone-13
+
+			// Domes
+			model = Adapter-Dome-A
+			model = Adapter-Dome-B
+			model = Adapter-Dome-Flat
+			model = Adapter-Dome-Half
+			model = Adapter-Dome-Half-Framed-S
+			model = Adapter-Dome-Half-Framed-M
+
+			// Adapters
+			model = Adapter-2-1-Flat
+			model = Adapter-2-1-Short
+			model = Adapter-2-1-Long
+			model = Adapter-3-1-Flat
+			model = Adapter-3-1-Short
+			model = Adapter-3-1-Long
+			model = Adapter-3-1-Extended
+			model = Adapter-3-2-Flat
+			model = Adapter-3-2-Short
+			model = Adapter-3-2-Long
+			model = Adapter-3-2-Extended
+			model = Adapter-4-1-Flat
+			model = Adapter-4-1-Short
+			model = Adapter-4-3-Flat
+			model = Adapter-4-3-Short
+			model = Adapter-4-3-Long
+
+			// Inverted Adapters
+			model = Adapter-1-2-Flat
+			model = Adapter-1-2-Short
+			model = Adapter-1-2-Long
+			model = Adapter-1-3-Flat
+			model = Adapter-1-3-Short
+			model = Adapter-1-3-Long
+			model = Adapter-2-3-Flat
+			model = Adapter-2-3-Short
+			model = Adapter-2-3-Long
+			model = Adapter-3-4-Flat
+			model = Adapter-3-4-Short
+			model = Adapter-3-4-Long
+
+			// Soyuz
+			model = Adapter-Soyuz
+			model = Adapter-R7
+			model = Adapter-Soyuz-S
+			model = Adapter-Soyuz-M
+			model = Adapter-Soyuz-L
+			model = Adapter-Soyuz-XL
+
+			// Split
+			model = Intertank-Split
+			model = Intertank-Sphere
+		}
+
+		MOUNT
+		{
+			// Generic
+			model = Model-None
+			
+			// Engine Mounts
+			model = Mount-S-IC
+			model = Mount-S-IC-45
+			model = Mount-S-II
+			model = Mount-S-IVB
+			model = Mount-Generic
+			model = Mount-Boattail
+			model = Mount-Shroud-Tight
+			model = Mount-Shroud-S
+			model = Mount-Shroud-M
+			model = Mount-Shroud-L
+			model = Mount-Shroud-XL
+			model = Mount-SLS
+			model = Mount-SLS-6
+			model = Mount-Pyrios
+			model = Mount-Nova
+			model = Mount-Direct
+			model = Mount-Delta-IV
+			model = Mount-RD-107
+			model = Mount-RD-108
+			model = Mount-RD-108-45
+			model = Mount-Skeletal-S
+			model = Mount-Skeletal-M
+			model = Mount-Skeletal-L
+			
+			// BDB Mounts
+			model = Mount-BDB-LDC-Single
+			model = Mount-BDB-LDC-Dual
+			model = Mount-BDB-LDC-Quad
+			model = Mount-BDB-LDC-x7
+			model = Mount-BDB-LDC-25Adapter
+			model = Mount-BDB-LDC-375Adapter
+			model = Mount-BDB-CentaurD
+			model = Mount-BDB-CentaurV
+			model = Mount-BDB-Saturn-SII
+			model = Mount-BDB-Saturn-SII-7X
+			
+			// Hephaistos
+			model = Mount-Hephaistos-Vulcan
+
+			// Domes
+			model = Atlas-Mount
+			model = Adapter-Dome-A
+			model = Adapter-Dome-B
+			model = Adapter-Dome-Flat
+			model = Adapter-Dome-Half
+			model = Adapter-Dome-Half-Framed-S
+			model = Adapter-Dome-Half-Framed-M
+
+			// Adapters
+			model = Adapter-2-1-Flat
+			model = Adapter-2-1-Short
+			model = Adapter-2-1-Long
+			model = Adapter-3-1-Flat
+			model = Adapter-3-1-Short
+			model = Adapter-3-1-Long
+			model = Adapter-3-1-Extended
+			model = Adapter-3-2-Flat
+			model = Adapter-3-2-Short
+			model = Adapter-3-2-Long
+			model = Adapter-3-2-Extended
+			model = Adapter-4-1-Flat
+			model = Adapter-4-1-Short
+			model = Adapter-4-3-Flat
+			model = Adapter-4-3-Short
+			model = Adapter-4-3-Long
+
+			// Inverted Adapters
+			model = Adapter-1-2-Flat
+			model = Adapter-1-2-Short
+			model = Adapter-1-2-Long
+			model = Adapter-1-3-Flat
+			model = Adapter-1-3-Short
+			model = Adapter-1-3-Long
+			model = Adapter-2-3-Flat
+			model = Adapter-2-3-Short
+			model = Adapter-2-3-Long
+			model = Adapter-3-4-Flat
+			model = Adapter-3-4-Short
+			model = Adapter-3-4-Long
+
+			// Soyuz
+			model = Adapter-Soyuz-S-BOT
+			model = Adapter-Soyuz-M-BOT
+			model = Adapter-Soyuz-L-BOT
+			model = Adapter-Soyuz-XL-BOT
+
+			// Split
+			model = Intertank-Split
+			model = Intertank-Sphere
+
+			// Nosecones
+			model = Nosecone-1
+			model = Nosecone-2
+			model = Nosecone-3
+			model = Nosecone-4
+			model = Nosecone-5
+			model = Nosecone-6
+			model = Nosecone-7
+			model = Nosecone-8
+			model = Nosecone-9
+			model = Nosecone-10
+			model = Nosecone-11
+			model = Nosecone-12
+			model = Nosecone-13
+		}
+	}
+
+	MODULE
+	{
+		name = ROLSelectableNodes
+		nodeName = noseinterstage
+		startsEnabled = false
+	}
+
+	MODULE
+	{
+		name = ROLSelectableNodes
+		nodeName = mountinterstage
+		startsEnabled = false
+	}
+
+	MODULE
+	{
+		name = ModuleToggleCrossfeed
+		toggleFlight = true
+		toggleEditor = true
+		crossfeedStatus = true
+	}
+
+	MODULE
+	{
+		name = SSTURecolorGUI
+	}
+
+	MODULE
+	{
+		name = ROLCollisionHandler
+	}
+
+	!rotanksApplyDefaults = delete
+}


### PR DESCRIPTION
Define 2 new tanks, ROT-MiscTank and ROT-MiscTank-Radial with CORES for
~200 models and variants from Squad, ReStock, Ven's and NFExploration
(with room for more models, and for more mods).

Volumes roughly right, but some could likely be finetuned.
Likewise Node positioning is still off a few pixels here and there

A few variants aren't getting quite the right textures; couldn't get
textureSets to use the existing textures, and Themes probably aren't
supported at all in ROLib. Still included the variants, can't hurt.

(includes the same bit of refactoring as #81 , now broken out into its own commit)