### PR TITLE
Misc-Radial tank tweaks

### DIFF
--- a/GameData/ROTanks/Compatibility/misc/ModelDataUtils.cfg
+++ b/GameData/ROTanks/Compatibility/misc/ModelDataUtils.cfg
@@ -6,11 +6,20 @@
 //    name = rotanks-xxx
 //    modelName = yyy
 //    diameter = nn // or both lowerDiameter and upperDiameter; default volume gets derived from this
-//    length = nn
+//    height = nn
 //    _rotanksApplyDefaults = true
 // }
 //
 // Runs in FOR[ROTanks]; avoids clobbering values already set.
+
+@ROL_MODEL[rotanks-*]:HAS[#_rotanksApplyDefaults,#_sphereDiameter]:FOR[ROTanks]
+{
+	// a sphere is 2/3 the volume of a same-dimensions cylinder
+	_defaultVolumeMultiplier = 0.66
+	&diameter = #$_sphereDiameter$
+	&height = #$_sphereDiameter$
+	!_sphereDiameter = delete
+}
 
 @ROL_MODEL[rotanks-*]:HAS[#_rotanksApplyDefaults,~upperDiameter]:FOR[ROTanks]
 {
@@ -25,6 +34,7 @@
 	// diameter MUST be set for scaling to match the diameter slider
 	&diameter = #$lowerDiameter$
 }
+
 @ROL_MODEL[rotanks-*]:HAS[#_rotanksApplyDefaults]:FOR[ROTanks]
 {
 	&orientation = CENTRAL

--- a/GameData/ROTanks/Compatibility/misc/NFExploration-ModelData.cfg
+++ b/GameData/ROTanks/Compatibility/misc/NFExploration-ModelData.cfg
@@ -100,9 +100,7 @@ ROL_MODEL:NEEDS[NearFutureExploration]
 	name = rotanks-nfex-tank-multi-8-gold
 	title = Tiny Gold
 	modelName = NearFutureExploration/Parts/FuelTank/nfex-fueltank-radial-tiny-1
-	diameter = 0.24
-	height = 0.24
-	volume = 0.007
+	_sphereDiameter = 0.24
 	rotationOffset = 0, 180, 0
 	positionOffset = -0.02, 0, 0
 	_rotanksApplyDefaults = true

--- a/GameData/ROTanks/Compatibility/misc/ReStock-ModelData.cfg
+++ b/GameData/ROTanks/Compatibility/misc/ReStock-ModelData.cfg
@@ -320,8 +320,7 @@ ROL_MODEL:NEEDS[ReStock]
 	name = rotanks-restock-tank-radial-round
 	title = Round
 	modelName = ReStock/Assets/FuelTank/restock-fueltank-foil-sphere-1
-	height = 0.625
-	diameter = 0.625
+	_sphereDiameter = 0.625
 }
 
 ROL_MODEL:NEEDS[ReStock]
@@ -338,8 +337,7 @@ ROL_MODEL:NEEDS[ReStock]
 	name = rotanks-restock-tank-rcs-radial-1
 	title = RCS
 	modelName = ReStock/Assets/FuelTank/restock-fuel-tank-rcs-radial-tiny-1
-	height = 0.34
-	diameter = 0.34
+	_sphereDiameter = 0.34
 }
 
 ROL_MODEL:NEEDS[ReStock]
@@ -347,8 +345,7 @@ ROL_MODEL:NEEDS[ReStock]
 	name = rotanks-restock-tank-rcs-radial-2
 	title = RCS 2
 	modelName = ReStock/Assets/FuelTank/restock-fueltank-rcs-radial-1
-	height = 0.56
-	diameter = 0.56
+	_sphereDiameter = 0.56
 	rotationOffset = 0, 90, 0
 	positionOffset = -0.2, 0, 0
 }
@@ -392,6 +389,11 @@ ROL_MODEL:NEEDS[ReStock]
 	@name = rotanks-restock-tank-goo-radial-compact
 	@title = Goo (bare)
 	@disableTransform = Mount_Truss
+}
+
+@ROL_MODEL[rotanks-restock-tank-*radial*]
+{
+	_rotanksApplyDefaults = true
 }
 
 

--- a/GameData/ROTanks/Compatibility/misc/Squad-ModelData.cfg
+++ b/GameData/ROTanks/Compatibility/misc/Squad-ModelData.cfg
@@ -475,7 +475,7 @@ ROL_MODEL:NEEDS[Squad]
 	modelName = Squad/Parts/FuelTank/xenonTankRadial/model
 	diameter = 0.3
 	height = 0.55
-	volume = 0.35
+	volume = 0.035
 	rotationOffset = 0, 90, 0
 	positionOffset = 0.20, 0, 0
 	_rotanksApplyDefaults = true
@@ -486,9 +486,8 @@ ROL_MODEL:NEEDS[Squad]
 	name = rotanks-squad-tank-radial-round
 	title = Round
 	modelName = Squad/Parts/FuelTank/FoilTanks/RadialTank_Round
-	diameter = 0.625
-	height = 0.128
 	_rotanksApplyDefaults = true
+	_sphereDiameter = 0.625
 }
 
 ROL_MODEL:NEEDS[Squad]


### PR DESCRIPTION
- Unbreak the Restock variants; they were missing all the defaults and ended up with no tank volume at all.
- Squad-xenon tank volume was 10x off.
- Squad-round tank wasn't round.
- The 95% handwaved volume multiplier is more generous than I realized for spheres. Add special treatement for spheres.