### PR TITLE
Updated mass values for all Saturn interstage variants based on data …

### DIFF
--- a/GameData/ROTanks/Data/Models/ModelData-Interstages-Katniss.cfg
+++ b/GameData/ROTanks/Data/Models/ModelData-Interstages-Katniss.cfg
@@ -8,7 +8,7 @@ ROL_MODEL
 	diameter = 10.3
 	upperDiameter = 10.3
 	lowerDiameter = 10.3
-	mass = 10.113
+	mass = 4.567
 	cost = 6294
 	height = 5.5
 	volume = 0
@@ -24,7 +24,7 @@ ROL_MODEL
 	diameter = 10.3
 	upperDiameter = 10.3
 	lowerDiameter = 10.3
-	mass = 10.863
+	mass = 5.398
 	cost = 6894
 	height = 6.5
 	volume = 0
@@ -40,7 +40,7 @@ ROL_MODEL
 	diameter = 10.453
 	upperDiameter = 10.453
 	lowerDiameter = 10.453
-	mass = 11.26
+	mass = 5.559
 	cost = 7136
 	height = 6.5
 	volume = 0
@@ -56,7 +56,7 @@ ROL_MODEL
 	diameter = 10.3
 	upperDiameter = 10.3
 	lowerDiameter = 10.3
-	mass = 10.988
+	mass = 6.644
 	cost = 7794
 	height = 8
 	volume = 0
@@ -72,7 +72,7 @@ ROL_MODEL
 	diameter = 10.3
 	upperDiameter = 10.3
 	lowerDiameter = 10.3
-	mass = 10.988
+	mass = 6.644
 	cost = 7794
 	height = 8
 	volume = 0
@@ -88,7 +88,7 @@ ROL_MODEL
 	diameter = 10.3
 	upperDiameter = 6.8
 	lowerDiameter = 10.3
-	mass = 9.474
+	mass = 3.460
 	cost = 5783
 	height = 5.6
 	volume = 0


### PR DESCRIPTION
…sourced from NASA publications


The weight changes are significant, on most parts it's half of the previous mass and on the S-IVB its almost 1/3.

The sources and subsequent calculation are documented in the initial commit message.